### PR TITLE
feat: better commands with expanded /help and 'usages' / 'descriptions' for each command

### DIFF
--- a/app/server/assets/locales/en.json
+++ b/app/server/assets/locales/en.json
@@ -22,6 +22,7 @@
   "Furniture not found on {{x}},{{z}}": "Furniture not found on {{x}},{{z}}",
   "Command not found": "Command not found",
   "{{command}}: {{description}}" : "{{command}}: {{description}}",
+  "No description available": "No description available",
   "Invalid arguments. None of the following usages matched: {{usages}}": "Invalid arguments. None of the following usages matched: {{usages}}",
 
   "command.ban.description": "Bans a user",

--- a/app/server/assets/locales/en.json
+++ b/app/server/assets/locales/en.json
@@ -19,5 +19,26 @@
   "There is no users on the whitelist": "There is no users on the whitelist",
   "New version {{newVersion}} available!": "New version {{newVersion}} available!",
   "Available commands: {{commands}}": "Available commands: {{commands}}",
-  "Furniture not found on {{x}},{{z}}": "Furniture not found on {{x}},{{z}}"
+  "Furniture not found on {{x}},{{z}}": "Furniture not found on {{x}},{{z}}",
+  "Command not found": "Command not found",
+  "{{command}}: {{description}}" : "{{command}}: {{description}}",
+  "Invalid arguments. None of the following usages matched: {{usages}}": "Invalid arguments. None of the following usages matched: {{usages}}",
+
+  "command.ban.description": "Bans a user",
+  "command.blacklist.description": "Manages the blacklist",
+  "command.clear.description": "Clears all furnitures from the room",
+  "command.deop.description": "Revokes operator status from a user",
+  "command.help.description": "Shows a list of available commands or information about a specific command",
+  "command.kick.description": "Kicks a user",
+  "command.move.description": "Moves a furniture to a new position",
+  "command.op.description": "Grants operator status to a user",
+  "command.rotate.description": "Rotates a furniture",
+  "command.set.description": "Sets a furniture in the room",
+  "command.stop.description": "Stops the server",
+  "command.teleport.description": "Links two teleports or links a teleport to a remote teleport",
+  "command.tp.description": "Teleports yourself to a location",
+  "command.unban.description": "Unbans a user",
+  "command.unset.description": "Removes a furniture from the room",
+  "command.update.description": "Checks for new versions and updates the server",
+  "command.whitelist.description": "Manages the whitelist"
 }

--- a/app/server/assets/locales/en.json
+++ b/app/server/assets/locales/en.json
@@ -21,7 +21,7 @@
   "Available commands: {{commands}}": "Available commands: {{commands}}",
   "Furniture not found on {{x}},{{z}}": "Furniture not found on {{x}},{{z}}",
   "Command not found": "Command not found",
-  "{{command}}: {{description}}" : "{{command}}: {{description}}",
+  "{{command}}: {{description}}": "{{command}}: {{description}}",
   "No description available": "No description available",
   "Invalid arguments. None of the following usages matched: {{usages}}": "Invalid arguments. None of the following usages matched: {{usages}}",
 

--- a/app/server/assets/locales/es.json
+++ b/app/server/assets/locales/es.json
@@ -21,9 +21,9 @@
   "Available commands: {{commands}}": "Comandos disponibles: {{commands}}",
   "Furniture not found on {{x}},{{z}}": "Furniture no encontrado en {{x}},{{z}}",
   "Command not found": "Comando no encontrado",
-  "{{command}}: {{description}}" : "{{command}}: {{description}}",
-  "No description available" : "No hay descripción disponible",
-  "Invalid arguments. None of the following usages matched: {{usages}}" : "Argumentos inválidos. Ninguno de los siguientes usos coincidió: {{usages}}",
+  "{{command}}: {{description}}": "{{command}}: {{description}}",
+  "No description available": "No hay descripción disponible",
+  "Invalid arguments. None of the following usages matched: {{usages}}": "Argumentos inválidos. Ninguno de los siguientes usos coincidió: {{usages}}",
 
   "command.ban.description": "Banea a un usuario",
   "command.blacklist.description": "Administra la lista negra",

--- a/app/server/assets/locales/es.json
+++ b/app/server/assets/locales/es.json
@@ -22,6 +22,7 @@
   "Furniture not found on {{x}},{{z}}": "Furniture no encontrado en {{x}},{{z}}",
   "Command not found": "Comando no encontrado",
   "{{command}}: {{description}}" : "{{command}}: {{description}}",
+  "No description available" : "No hay descripción disponible",
   "Invalid arguments. None of the following usages matched: {{usages}}" : "Argumentos inválidos. Ninguno de los siguientes usos coincidió: {{usages}}",
 
   "command.ban.description": "Banea a un usuario",

--- a/app/server/assets/locales/es.json
+++ b/app/server/assets/locales/es.json
@@ -19,5 +19,26 @@
   "There is no users on the whitelist": "No hay usuarios en la lista blanca",
   "New version {{newVersion}} available!": "Nueva versión {{newVersion}} disponible!",
   "Available commands: {{commands}}": "Comandos disponibles: {{commands}}",
-  "Furniture not found on {{x}},{{z}}": "Furniture no encontrado en {{x}},{{z}}"
+  "Furniture not found on {{x}},{{z}}": "Furniture no encontrado en {{x}},{{z}}",
+  "Command not found": "Comando no encontrado",
+  "{{command}}: {{description}}" : "{{command}}: {{description}}",
+  "Invalid arguments. None of the following usages matched: {{usages}}" : "Argumentos inválidos. Ninguno de los siguientes usos coincidió: {{usages}}",
+
+  "command.ban.description": "Banea a un usuario",
+  "command.blacklist.description": "Administra la lista negra",
+  "command.clear.description": "Elimina todos los muebles de la sala",
+  "command.deop.description": "Revoca el estado de operador a un usuario",
+  "command.help.description": "Muestra una lista de comandos disponibles o información sobre un comando específico",
+  "command.kick.description": "Expulsa a un usuario",
+  "command.move.description": "Mueve un mueble a una nueva posición",
+  "command.op.description": "Concede el estado de operador a un usuario",
+  "command.rotate.description": "Rota un mueble",
+  "command.set.description": "Coloca un mueble en la sala",
+  "command.stop.description": "Detiene el servidor",
+  "command.teleport.description": "Vincula dos teletransportadores o vincula un teletransportador a un teletransportador remoto",
+  "command.tp.description": "Te teletransporta a ti mismo",
+  "command.unban.description": "Desbanea a un usuario",
+  "command.unset.description": "Elimina un mueble de la sala",
+  "command.update.description": "Comprueba nuevas versiones y actualiza el servidor",
+  "command.whitelist.description": "Administra la lista blanca"
 }

--- a/app/server/src/modules/system/commands/ban.command.ts
+++ b/app/server/src/modules/system/commands/ban.command.ts
@@ -5,6 +5,8 @@ import { ProxyEvent } from "shared/enums/main.ts";
 
 export const banCommand: Command = {
   command: "ban",
+  usages: ["<username>"],
+  description: "command.ban.description",
   func: async ({ user, args }) => {
     const username = args[0] as string;
     if (!username) return;

--- a/app/server/src/modules/system/commands/blacklist.command.ts
+++ b/app/server/src/modules/system/commands/blacklist.command.ts
@@ -58,10 +58,7 @@ const list = (config: UsersConfig, _: string[], user: UserMutable) => {
 
 export const blacklistCommand: Command = {
   command: "blacklist",
-  usages: [
-      "<add|remove> <username>",
-      "<on|off|list>",
-  ],
+  usages: ["<add|remove> <username>", "<on|off|list>"],
   description: "commmands.blacklist.description",
   func: async ({ user, args }) => {
     const action = args[0] as ListActions;

--- a/app/server/src/modules/system/commands/blacklist.command.ts
+++ b/app/server/src/modules/system/commands/blacklist.command.ts
@@ -58,6 +58,11 @@ const list = (config: UsersConfig, _: string[], user: UserMutable) => {
 
 export const blacklistCommand: Command = {
   command: "blacklist",
+  usages: [
+      "<add|remove> <username>",
+      "<on|off|list>",
+  ],
+  description: "commmands.blacklist.description",
   func: async ({ user, args }) => {
     const action = args[0] as ListActions;
     if (!action) return;

--- a/app/server/src/modules/system/commands/clear.command.ts
+++ b/app/server/src/modules/system/commands/clear.command.ts
@@ -4,6 +4,8 @@ import { System } from "modules/system/main.ts";
 
 export const clearCommand: Command = {
   command: "clear",
+  usages: [""],
+  description: "command.clear.description",
   func: async ({ user, args }) => {
     const roomId = user.getRoom();
     if (!roomId) return;

--- a/app/server/src/modules/system/commands/deop.command.ts
+++ b/app/server/src/modules/system/commands/deop.command.ts
@@ -16,9 +16,6 @@ export const deopCommand: Command = {
 
     await System.game.users.setConfig(config);
 
-    const position = user.getPosition();
-    console.log(position);
-
     user.emit(ProxyEvent.SYSTEM_MESSAGE, {
       message: __(user.getLanguage())("User {{username}} is no longer op", {
         username,

--- a/app/server/src/modules/system/commands/deop.command.ts
+++ b/app/server/src/modules/system/commands/deop.command.ts
@@ -5,6 +5,8 @@ import { System } from "modules/system/main.ts";
 
 export const deopCommand: Command = {
   command: "deop",
+  usages: ["<username>"],
+  description: "commands.deop.description",
   func: async ({ user, args }) => {
     const username = args[0] as string;
     if (!username) return;
@@ -13,6 +15,9 @@ export const deopCommand: Command = {
     config.op.users = config.op.users.filter((u) => u !== username);
 
     await System.game.users.setConfig(config);
+
+    const position = user.getPosition();
+    console.log(position);
 
     user.emit(ProxyEvent.SYSTEM_MESSAGE, {
       message: __(user.getLanguage())("User {{username}} is no longer op", {

--- a/app/server/src/modules/system/commands/help.command.ts
+++ b/app/server/src/modules/system/commands/help.command.ts
@@ -5,7 +5,31 @@ import { __ } from "shared/utils/main.ts";
 
 export const helpCommand: Command = {
   command: "help",
-  func: async ({ user }) => {
+  usages: [
+      "",
+      "<command>",
+  ],
+  description: "command.help.description",
+  func: async ({ user, args }) => {
+    if (args.length === 1) {
+        const command = args[0] as string;
+        const cmd = commandList.find((c) => c.command === command);
+        if (!cmd) {
+            user.emit(ProxyEvent.SYSTEM_MESSAGE, {
+            message: __(user.getLanguage())("Command not found"),
+            });
+            return;
+        }
+
+        user.emit(ProxyEvent.SYSTEM_MESSAGE, {
+            message: __(user.getLanguage())("{{command}}: {{description}}", {
+                command: cmd.command,
+                description: __(user.getLanguage())(cmd.description), // Translate description
+            }),
+        });
+        return;
+    }
+
     user.emit(ProxyEvent.SYSTEM_MESSAGE, {
       message: __(user.getLanguage())("Available commands: {{commands}}", {
         commands: commandList

--- a/app/server/src/modules/system/commands/help.command.ts
+++ b/app/server/src/modules/system/commands/help.command.ts
@@ -21,10 +21,12 @@ export const helpCommand: Command = {
             return;
         }
 
+        const description = cmd.description ? __(user.getLanguage())(cmd.description) : __(user.getLanguage())("No description available");
+
         user.emit(ProxyEvent.SYSTEM_MESSAGE, {
             message: __(user.getLanguage())("{{command}}: {{description}}", {
                 command: cmd.command,
-                description: __(user.getLanguage())(cmd.description), // Translate description
+                description: description,
             }),
         });
         return;

--- a/app/server/src/modules/system/commands/help.command.ts
+++ b/app/server/src/modules/system/commands/help.command.ts
@@ -5,31 +5,30 @@ import { __ } from "shared/utils/main.ts";
 
 export const helpCommand: Command = {
   command: "help",
-  usages: [
-      "",
-      "<command>",
-  ],
+  usages: ["", "<command>"],
   description: "command.help.description",
   func: async ({ user, args }) => {
     if (args.length === 1) {
-        const command = args[0] as string;
-        const cmd = commandList.find((c) => c.command === command);
-        if (!cmd) {
-            user.emit(ProxyEvent.SYSTEM_MESSAGE, {
-            message: __(user.getLanguage())("Command not found"),
-            });
-            return;
-        }
-
-        const description = cmd.description ? __(user.getLanguage())(cmd.description) : __(user.getLanguage())("No description available");
-
+      const command = args[0] as string;
+      const cmd = commandList.find((c) => c.command === command);
+      if (!cmd) {
         user.emit(ProxyEvent.SYSTEM_MESSAGE, {
-            message: __(user.getLanguage())("{{command}}: {{description}}", {
-                command: cmd.command,
-                description: description,
-            }),
+          message: __(user.getLanguage())("Command not found"),
         });
         return;
+      }
+
+      const description = cmd.description
+        ? __(user.getLanguage())(cmd.description)
+        : __(user.getLanguage())("No description available");
+
+      user.emit(ProxyEvent.SYSTEM_MESSAGE, {
+        message: __(user.getLanguage())("{{command}}: {{description}}", {
+          command: cmd.command,
+          description: description,
+        }),
+      });
+      return;
     }
 
     user.emit(ProxyEvent.SYSTEM_MESSAGE, {

--- a/app/server/src/modules/system/commands/kick.command.ts
+++ b/app/server/src/modules/system/commands/kick.command.ts
@@ -5,6 +5,8 @@ import { __ } from "shared/utils/main.ts";
 
 export const kickCommand: Command = {
   command: "kick",
+  usages: ["<username>"],
+  description: "command.kick.description",
   func: async ({ user, args }) => {
     const username = args[0] as string;
     if (!username) return;

--- a/app/server/src/modules/system/commands/main.ts
+++ b/app/server/src/modules/system/commands/main.ts
@@ -19,9 +19,9 @@ import { teleportCommand } from "./teleport.command.ts";
 import { clearCommand } from "./clear.command.ts";
 import { rotateCommand } from "./rotate.command.ts";
 import { moveCommand } from "./move.command.ts";
-import {ProxyEvent} from "../../../shared/enums/event.enum.ts";
-import {validateCommandUsages} from "../../../shared/utils/commands.utils.ts";
-import {__} from "../../../shared/utils/languages.utils.ts";
+import { ProxyEvent } from "../../../shared/enums/event.enum.ts";
+import { validateCommandUsages } from "../../../shared/utils/commands.utils.ts";
+import { __ } from "../../../shared/utils/languages.utils.ts";
 
 export const commandList = [
   stopCommand,
@@ -78,7 +78,7 @@ export const executeCommand = ({
   const usages = foundCommand.usages || [];
 
   if (usages.length > 0) {
-    const validation = validateCommandUsages( foundCommand, _, user );
+    const validation = validateCommandUsages(foundCommand, _, user);
     if (!validation.isValid) {
       user.emit(ProxyEvent.SYSTEM_MESSAGE, {
         message: `${validation.errorMessage}`,

--- a/app/server/src/modules/system/commands/main.ts
+++ b/app/server/src/modules/system/commands/main.ts
@@ -19,9 +19,9 @@ import { teleportCommand } from "./teleport.command.ts";
 import { clearCommand } from "./clear.command.ts";
 import { rotateCommand } from "./rotate.command.ts";
 import { moveCommand } from "./move.command.ts";
-import { ProxyEvent } from "../../../shared/enums/event.enum.ts";
-import { validateCommandUsages } from "../../../shared/utils/commands.utils.ts";
-import { __ } from "../../../shared/utils/languages.utils.ts";
+import { ProxyEvent } from "shared/enums/event.enum.ts";
+import { validateCommandUsages } from "shared/utils/commands.utils.ts";
+import { __ } from "shared/utils/languages.utils.ts";
 
 export const commandList = [
   stopCommand,

--- a/app/server/src/modules/system/commands/main.ts
+++ b/app/server/src/modules/system/commands/main.ts
@@ -21,6 +21,7 @@ import { rotateCommand } from "./rotate.command.ts";
 import { moveCommand } from "./move.command.ts";
 import {ProxyEvent} from "../../../shared/enums/event.enum.ts";
 import {validateCommandUsages} from "../../../shared/utils/commands.utils.ts";
+import {__} from "../../../shared/utils/languages.utils.ts";
 
 export const commandList = [
   stopCommand,
@@ -64,7 +65,12 @@ export const executeCommand = ({
   const { _ } = parseArgs(message.substring(1, message.length).split(" "));
 
   const foundCommand = commandList.find(({ command }) => _[0] === command);
-  if (!foundCommand) return true;
+  if (!foundCommand) {
+    user.emit(ProxyEvent.SYSTEM_MESSAGE, {
+      message: __(user.getLanguage())("Command not found"),
+    });
+    return true;
+  }
 
   log(`Command /${foundCommand.command} executed by ${user.getUsername()}!`);
   _.shift();

--- a/app/server/src/modules/system/commands/main.ts
+++ b/app/server/src/modules/system/commands/main.ts
@@ -19,6 +19,8 @@ import { teleportCommand } from "./teleport.command.ts";
 import { clearCommand } from "./clear.command.ts";
 import { rotateCommand } from "./rotate.command.ts";
 import { moveCommand } from "./move.command.ts";
+import {ProxyEvent} from "../../../shared/enums/event.enum.ts";
+import {validateCommandUsages} from "../../../shared/utils/commands.utils.ts";
 
 export const commandList = [
   stopCommand,
@@ -66,6 +68,19 @@ export const executeCommand = ({
 
   log(`Command /${foundCommand.command} executed by ${user.getUsername()}!`);
   _.shift();
+
+  const usages = foundCommand.usages || [];
+
+  if (usages.length > 0) {
+    const validation = validateCommandUsages( foundCommand, _, user );
+    if (!validation.isValid) {
+      user.emit(ProxyEvent.SYSTEM_MESSAGE, {
+        message: `${validation.errorMessage}`,
+      });
+      return true;
+    }
+  }
+
   try {
     foundCommand.func({ user, args: _ } as any);
   } catch (e) {

--- a/app/server/src/modules/system/commands/move.command.ts
+++ b/app/server/src/modules/system/commands/move.command.ts
@@ -6,6 +6,8 @@ import { CrossDirection } from "@oh/utils";
 
 export const moveCommand: Command = {
   command: "move",
+  usages: ["<furniture_id> <x> <z> <direction> [wallX] [wallY]"],
+  description: "command.move.description",
   func: async ({ user, args }) => {
     const [id, x, z, direction, wallX, wallY] = args as [
       string,

--- a/app/server/src/modules/system/commands/op.command.ts
+++ b/app/server/src/modules/system/commands/op.command.ts
@@ -7,7 +7,7 @@ export const opCommand: Command = {
   command: "op",
   usages: ["<username>"],
   description: "command.op.description",
-  func: async function ({ user, args }) {
+  func: async ({ user, args }) => {
     const username = args[0] as string;
     if (!username) return;
 

--- a/app/server/src/modules/system/commands/op.command.ts
+++ b/app/server/src/modules/system/commands/op.command.ts
@@ -5,7 +5,9 @@ import { System } from "modules/system/main.ts";
 
 export const opCommand: Command = {
   command: "op",
-  func: async ({ user, args }) => {
+  usages: ["<username>"],
+  description: "command.op.description",
+  func: async function ({ user, args }) {
     const username = args[0] as string;
     if (!username) return;
 

--- a/app/server/src/modules/system/commands/op.command.ts
+++ b/app/server/src/modules/system/commands/op.command.ts
@@ -6,7 +6,6 @@ import { System } from "modules/system/main.ts";
 export const opCommand: Command = {
   command: "op",
   usages: ["<username>"],
-  description: "command.op.description",
   func: async ({ user, args }) => {
     const username = args[0] as string;
     if (!username) return;

--- a/app/server/src/modules/system/commands/rotate.command.ts
+++ b/app/server/src/modules/system/commands/rotate.command.ts
@@ -6,6 +6,8 @@ import { CrossDirection } from "@oh/utils";
 
 export const rotateCommand: Command = {
   command: "rotate",
+  usages: ["<furniture_id> <true|false>"],
+  description: "command.rotate.description",
   func: async ({ user, args }) => {
     const [id, clockwise] = args as [string, string];
 
@@ -16,6 +18,8 @@ export const rotateCommand: Command = {
     const furniture = room
       .getFurnitures()
       .find((furniture) => furniture.id === id);
+
+    console.log(room.getFurnitures())
 
     if (!furniture) {
       user.emit(ProxyEvent.SYSTEM_MESSAGE, {

--- a/app/server/src/modules/system/commands/rotate.command.ts
+++ b/app/server/src/modules/system/commands/rotate.command.ts
@@ -19,8 +19,6 @@ export const rotateCommand: Command = {
       .getFurnitures()
       .find((furniture) => furniture.id === id);
 
-    console.log(room.getFurnitures())
-
     if (!furniture) {
       user.emit(ProxyEvent.SYSTEM_MESSAGE, {
         message: __(user.getLanguage())("Furniture not found!"),

--- a/app/server/src/modules/system/commands/set.command.ts
+++ b/app/server/src/modules/system/commands/set.command.ts
@@ -21,7 +21,6 @@ export const setCommand: Command = {
       number,
       number,
     ];
-    console.log(furnitureId, x, z, direction, wallX, wallY)
     if (!furnitureId || isNaN(x) || isNaN(z) || isNaN(direction)) return;
 
     if (CrossDirection.NORTH > direction || direction > CrossDirection.WEST)

--- a/app/server/src/modules/system/commands/set.command.ts
+++ b/app/server/src/modules/system/commands/set.command.ts
@@ -8,6 +8,8 @@ import { isWallRenderable } from "shared/utils/rooms.utils.ts";
 
 export const setCommand: Command = {
   command: "set",
+  usages: ["<furniture_id> <x> <z> <direction> [wallX] [wallY]"],
+  description: "command.set.description",
   func: async ({ user, args }) => {
     if (3 > args.length) return;
 
@@ -19,6 +21,7 @@ export const setCommand: Command = {
       number,
       number,
     ];
+    console.log(furnitureId, x, z, direction, wallX, wallY)
     if (!furnitureId || isNaN(x) || isNaN(z) || isNaN(direction)) return;
 
     if (CrossDirection.NORTH > direction || direction > CrossDirection.WEST)

--- a/app/server/src/modules/system/commands/stop.command.ts
+++ b/app/server/src/modules/system/commands/stop.command.ts
@@ -4,6 +4,8 @@ import { __ } from "shared/utils/main.ts";
 
 export const stopCommand: Command = {
   command: "stop",
+  usages: [""],
+  description: "command.stop.description",
   func: ({ user }) => {
     user.emit(ProxyEvent.SYSTEM_MESSAGE, {
       message: __(user.getLanguage())("Stopping server..."),

--- a/app/server/src/modules/system/commands/teleport.command.ts
+++ b/app/server/src/modules/system/commands/teleport.command.ts
@@ -5,8 +5,7 @@ import { __ } from "shared/utils/languages.utils.ts";
 
 export const teleportCommand: Command = {
   command: "teleport",
-  usages: ["link <teleportIdA> <teleportIdB>",
-           "remote <teleportIdA> <linkId>"],
+  usages: ["link <teleportIdA> <teleportIdB>", "remote <teleportIdA> <linkId>"],
   description: "command.teleport.description",
   func: async ({ user, args }) => {
     const [type, ...moreArgs] = args as string[];

--- a/app/server/src/modules/system/commands/teleport.command.ts
+++ b/app/server/src/modules/system/commands/teleport.command.ts
@@ -5,6 +5,9 @@ import { __ } from "shared/utils/languages.utils.ts";
 
 export const teleportCommand: Command = {
   command: "teleport",
+  usages: ["link <teleportIdA> <teleportIdB>",
+           "remote <teleportIdA> <linkId>"],
+  description: "command.teleport.description",
   func: async ({ user, args }) => {
     const [type, ...moreArgs] = args as string[];
 

--- a/app/server/src/modules/system/commands/tp.command.ts
+++ b/app/server/src/modules/system/commands/tp.command.ts
@@ -4,6 +4,8 @@ import { System } from "modules/system/main.ts";
 
 export const tpCommand: Command = {
   command: "tp",
+  usages: ["<x> <z>"],
+  description: "command.tp.description",
   func: async ({ user, args }) => {
     if (args.length !== 2) return;
 

--- a/app/server/src/modules/system/commands/unban.command.ts
+++ b/app/server/src/modules/system/commands/unban.command.ts
@@ -5,6 +5,8 @@ import { System } from "modules/system/main.ts";
 
 export const unbanCommand: Command = {
   command: "unban",
+  usages: ["<username>"],
+  description: "command.unban.description",
   func: async ({ user, args }) => {
     const username = args[0] as string;
     if (!username) return;

--- a/app/server/src/modules/system/commands/unset.command.ts
+++ b/app/server/src/modules/system/commands/unset.command.ts
@@ -5,6 +5,8 @@ import { __ } from "shared/utils/main.ts";
 
 export const unsetCommand: Command = {
   command: "unset",
+  usages: ["<furniture_id>"],
+  description: "command.unset.description",
   func: async ({ user, args }) => {
     if (1 !== args.length) return;
 

--- a/app/server/src/modules/system/commands/update.command.ts
+++ b/app/server/src/modules/system/commands/update.command.ts
@@ -5,6 +5,8 @@ import { __ } from "shared/utils/main.ts";
 
 export const updateCommand: Command = {
   command: "update",
+  usages: [""],
+  description: "command.update.description",
   func: async ({ user }) => {
     System.proxy.$emit(ProxyEvent.$UPDATE);
     user.emit(ProxyEvent.SYSTEM_MESSAGE, {

--- a/app/server/src/modules/system/commands/whitelist.command.ts
+++ b/app/server/src/modules/system/commands/whitelist.command.ts
@@ -58,6 +58,11 @@ const list = (config: UsersConfig, _: string[], user: UserMutable) => {
 
 export const whitelistCommand: Command = {
   command: "whitelist",
+  usages: [
+    "<add|remove> <username>",
+    "<on|off|list>",
+  ],
+  description: "command.whitelist.description",
   func: async ({ user, args }) => {
     const action = args[0] as ListActions;
     if (!action) return;

--- a/app/server/src/modules/system/commands/whitelist.command.ts
+++ b/app/server/src/modules/system/commands/whitelist.command.ts
@@ -58,10 +58,7 @@ const list = (config: UsersConfig, _: string[], user: UserMutable) => {
 
 export const whitelistCommand: Command = {
   command: "whitelist",
-  usages: [
-    "<add|remove> <username>",
-    "<on|off|list>",
-  ],
+  usages: ["<add|remove> <username>", "<on|off|list>"],
   description: "command.whitelist.description",
   func: async ({ user, args }) => {
     const action = args[0] as ListActions;

--- a/app/server/src/shared/types/commands.types.ts
+++ b/app/server/src/shared/types/commands.types.ts
@@ -2,6 +2,8 @@ import { UserMutable } from "./user.types.ts";
 
 export type Command = {
   command: string;
+  usages?: string[];
+  description?: string;
   func: (data: {
     args: (string | number)[];
     user: UserMutable;

--- a/app/server/src/shared/utils/commands.utils.ts
+++ b/app/server/src/shared/utils/commands.utils.ts
@@ -1,68 +1,68 @@
-import {Command} from "../types/commands.types.ts";
-import {UserMutable} from "../types/user.types.ts";
-import {__} from "./languages.utils.ts";
+import { Command } from "../types/commands.types.ts";
+import { UserMutable } from "../types/user.types.ts";
+import { __ } from "./languages.utils.ts";
 
 export const validateCommandUsages = (
-    foundCommand: Command,
-    args: string[],
-    user: UserMutable
-):{ isValid: boolean; errorMessage?: string } => {
-    const argsRegex = /<[^>]+>|\[[^\]]+\]|\S+/g // Matches "<...>", "[...]", "<...|...|...>", "[...|...|...]" and literals
-    for (const usage of foundCommand.usages) {
-        const usageTokens = usage.match(argsRegex);
+  foundCommand: Command,
+  args: string[],
+  user: UserMutable,
+): { isValid: boolean; errorMessage?: string } => {
+  const argsRegex = /<[^>]+>|\[[^\]]+\]|\S+/g; // Matches "<...>", "[...]", "<...|...|...>", "[...|...|...]" and literals
+  for (const usage of foundCommand.usages) {
+    const usageTokens = usage.match(argsRegex);
 
-        if (!usageTokens) {
-            if (args.length === 0) return { isValid: true };
-            continue; // Try the next usage pattern
-        }
-
-        let valid = true;
-        for (let i = 0; i < usageTokens.length; i++) {
-            const token = usageTokens[i];
-            const arg = args[i];
-
-            // Check if token is a literal keyword (e.g., "link" or "remote")
-            if (!token.startsWith("<") && !token.startsWith("[")) {
-                if (token !== arg) {
-                    valid = false;
-                    break;
-                }
-                continue;
-            }
-
-            const isOptional = token.startsWith("[") && token.endsWith("]");
-            const cleanToken = token.replace(/[<>\[\]]/g, "");
-
-            if (arg === undefined) {
-                if (!isOptional) {
-                    valid = false;
-                    break;
-                }
-                continue;
-            }
-
-            // Validate against choices (e.g., "<on|off|list>")
-            const choices = cleanToken.split("|");
-            if (choices.length > 1 && !choices.includes(arg)) {
-                valid = false;
-                break;
-            }
-        }
-
-        if (valid && args.length === usageTokens.length) {
-            return { isValid: true };
-        }
+    if (!usageTokens) {
+      if (args.length === 0) return { isValid: true };
+      continue; // Try the next usage pattern
     }
 
-    return {
-        isValid: false,
-        errorMessage: __(user.getLanguage())(
-            "Invalid arguments. None of the following usages matched: {{usages}}",
-            {
-                usages: foundCommand.usages
-                    .map((usage) => `/${foundCommand.command} ${usage}`)
-                    .join(" or "),
-            }
-        ),
-    };
+    let valid = true;
+    for (let i = 0; i < usageTokens.length; i++) {
+      const token = usageTokens[i];
+      const arg = args[i];
+
+      // Check if token is a literal keyword (e.g., "link" or "remote")
+      if (!token.startsWith("<") && !token.startsWith("[")) {
+        if (token !== arg) {
+          valid = false;
+          break;
+        }
+        continue;
+      }
+
+      const isOptional = token.startsWith("[") && token.endsWith("]");
+      const cleanToken = token.replace(/[<>\[\]]/g, "");
+
+      if (arg === undefined) {
+        if (!isOptional) {
+          valid = false;
+          break;
+        }
+        continue;
+      }
+
+      // Validate against choices (e.g., "<on|off|list>")
+      const choices = cleanToken.split("|");
+      if (choices.length > 1 && !choices.includes(arg)) {
+        valid = false;
+        break;
+      }
+    }
+
+    if (valid && args.length === usageTokens.length) {
+      return { isValid: true };
+    }
+  }
+
+  return {
+    isValid: false,
+    errorMessage: __(user.getLanguage())(
+      "Invalid arguments. None of the following usages matched: {{usages}}",
+      {
+        usages: foundCommand.usages
+          .map((usage) => `/${foundCommand.command} ${usage}`)
+          .join(" or "),
+      },
+    ),
+  };
 };

--- a/app/server/src/shared/utils/commands.utils.ts
+++ b/app/server/src/shared/utils/commands.utils.ts
@@ -1,0 +1,68 @@
+import {Command} from "../types/commands.types.ts";
+import {UserMutable} from "../types/user.types.ts";
+import {__} from "./languages.utils.ts";
+
+export const validateCommandUsages = (
+    foundCommand: Command,
+    args: string[],
+    user: UserMutable
+):{ isValid: boolean; errorMessage?: string } => {
+    const argsRegex = /<[^>]+>|\[[^\]]+\]|\S+/g // Matches "<...>", "[...]", "<...|...|...>", "[...|...|...]" and literals
+    for (const usage of foundCommand.usages) {
+        const usageTokens = usage.match(argsRegex);
+
+        if (!usageTokens) {
+            if (args.length === 0) return { isValid: true };
+            continue; // Try the next usage pattern
+        }
+
+        let valid = true;
+        for (let i = 0; i < usageTokens.length; i++) {
+            const token = usageTokens[i];
+            const arg = args[i];
+
+            // Check if token is a literal keyword (e.g., "link" or "remote")
+            if (!token.startsWith("<") && !token.startsWith("[")) {
+                if (token !== arg) {
+                    valid = false;
+                    break;
+                }
+                continue;
+            }
+
+            const isOptional = token.startsWith("[") && token.endsWith("]");
+            const cleanToken = token.replace(/[<>\[\]]/g, "");
+
+            if (arg === undefined) {
+                if (!isOptional) {
+                    valid = false;
+                    break;
+                }
+                continue;
+            }
+
+            // Validate against choices (e.g., "<on|off|list>")
+            const choices = cleanToken.split("|");
+            if (choices.length > 1 && !choices.includes(arg)) {
+                valid = false;
+                break;
+            }
+        }
+
+        if (valid && args.length === usageTokens.length) {
+            return { isValid: true };
+        }
+    }
+
+    return {
+        isValid: false,
+        errorMessage: __(user.getLanguage())(
+            "Invalid arguments. None of the following usages matched: {{usages}}",
+            {
+                usages: foundCommand.usages
+                    .map((usage) => `/${foundCommand.command} ${usage}`)
+                    .join(" or "),
+            }
+        ),
+    };
+};


### PR DESCRIPTION
# Description

Improves the commands by making them more descriptive and providing usage information when an error occurs. The `/help` command has also been expanded to include command descriptions.

## Key Changes

- Usage information is displayed when a command is used incorrectly.
- `/help` now shows both the list of commands and their descriptions.
- Shows command not found when the command is not found

## Screenshots

### Help Descriptions
![image](https://github.com/user-attachments/assets/e69c23d4-b59e-4cbb-a29b-9801ea31186d)
![image](https://github.com/user-attachments/assets/6bddb349-6097-4734-ba7f-7708ebdcd96d)
![image](https://github.com/user-attachments/assets/5202182b-b4fa-48cd-b89b-519969cf75ce)

### Usage on error
![image](https://github.com/user-attachments/assets/c1aa9b13-531c-497b-b758-0b68b72a4e1f)
![image](https://github.com/user-attachments/assets/7867c3f8-3b6f-469b-97c3-0dbbf28ddb60)

### Command not found
![image](https://github.com/user-attachments/assets/c7fd7ccc-b961-46d7-8e29-9d70a62310d5)
![image](https://github.com/user-attachments/assets/5f1318cf-e4ca-4ef0-aeed-ff79936e758a)



## Other considerations
- If a command doesn't want to be restricted by its usages, simply set 'usages' to an empty array '[ ]' 
- The usage validator parses '<...>' as required, '[...]' as non-required, '<...|...|...>' as required options, and also accepts literals (for commands like /teleport link or /teleport remote)
- My translation styles are pretty different that the ones already in place, I don't think that using a full english sentence as a keyword is a good idea in this translation jsons. I followed it for other messages, but for the descriptions, I used this other style.
- I don't think I quite grasped the purpose for /teleport remote, feel free to correct me on the 'usage' or 'description' if what I wrote is incorrect info.





