### PR TITLE
fix: memory leak when switching tabs - fix #526

### DIFF
--- a/app/client/src/modules/interfaces/catalog/catalog-modal.component.ts
+++ b/app/client/src/modules/interfaces/catalog/catalog-modal.component.ts
@@ -130,9 +130,15 @@ export const catalogModalComponent: ContainerComponent<Props> = (
           SpriteSheetEnum.CATALOG,
         );
 
-        $content.remove(categoryComponentMap[selectedCategory]);
+        categoryComponentMap[selectedCategory].setVisible(false);
         selectedCategory = categoryIndex;
-        $content.add(categoryComponentMap[selectedCategory]);
+        const isAlreadyAdded = $content
+          .getChildren()
+          .includes(categoryComponentMap[selectedCategory]);
+        if (!isAlreadyAdded) {
+          $content.add(categoryComponentMap[selectedCategory]);
+        }
+        categoryComponentMap[selectedCategory].setVisible(true);
       });
       const tabItemTexture = sprite({
         spriteSheet: SpriteSheetEnum.CATALOG,

--- a/app/client/src/modules/interfaces/catalog/catalog-section.component.ts
+++ b/app/client/src/modules/interfaces/catalog/catalog-section.component.ts
@@ -99,78 +99,81 @@ export const catalogSectionComponent: ContainerComponent<Props> = (props) => {
       ...catalogFurniture.map((furniture) => furniture.id),
     );
 
-    for (const furniture of catalogFurniture) {
-      const { id, price } = furniture;
+    // TODO - remove for loop once we check the fix works
+    for (let i = 0; i < 20; i++) {
+      for (const furniture of catalogFurniture) {
+        const { id, price } = furniture;
 
-      const furnitureData = System.game.furniture.get(id);
+        const furnitureData = System.game.furniture.get(id);
 
-      const textures = Object.keys(
-        global.spriteSheets.get(furnitureData.spriteSheet).textures,
-      );
+        const textures = Object.keys(
+          global.spriteSheets.get(furnitureData.spriteSheet).textures,
+        );
 
-      let { texture, bounds } = furnitureData.icon;
-      let spriteSheet = furnitureData.spriteSheet;
+        let { texture, bounds } = furnitureData.icon;
+        let spriteSheet = furnitureData.spriteSheet;
 
-      if (!textures.includes(texture)) {
-        await System.game.furniture.loadFurniture(DEFAULT_FURNITURE);
-        const defaultSpriteSheetObject =
-          System.game.furniture.get(DEFAULT_FURNITURE);
-        texture = defaultSpriteSheetObject.icon.texture;
-        bounds = defaultSpriteSheetObject.icon.bounds;
-        spriteSheet = defaultSpriteSheetObject.spriteSheet;
+        if (!textures.includes(texture)) {
+          await System.game.furniture.loadFurniture(DEFAULT_FURNITURE);
+          const defaultSpriteSheetObject =
+            System.game.furniture.get(DEFAULT_FURNITURE);
+          texture = defaultSpriteSheetObject.icon.texture;
+          bounds = defaultSpriteSheetObject.icon.bounds;
+          spriteSheet = defaultSpriteSheetObject.spriteSheet;
+        }
+
+        const $furnitureContainer = container({
+          size: {
+            width: size.width,
+            height: bounds.height + padding,
+          },
+          position: {
+            x: 0,
+            y: currentY,
+          },
+          eventMode: EventMode.STATIC,
+          cursor: Cursor.POINTER,
+        });
+
+        $furnitureList.add($furnitureContainer);
+
+        const $sprite = sprite({
+          spriteSheet: spriteSheet,
+          texture: texture,
+          position: {
+            x: 0,
+            y: 0,
+          },
+          bounds: bounds,
+          pivot: {
+            x: 0,
+            y: 0,
+          },
+          eventMode: EventMode.STATIC,
+          cursor: Cursor.POINTER,
+        });
+
+        const $text = textSprite({
+          text: furniture.id,
+          spriteSheet: SpriteSheetEnum.DEFAULT_FONT,
+          color: 0,
+          position: {
+            x: Math.max(30, bounds.width + 5),
+            y: bounds.height / 2 - 2,
+          },
+          eventMode: EventMode.STATIC,
+          cursor: Cursor.POINTER,
+        });
+
+        currentY += bounds.height + padding;
+        $furnitureContainer.add($sprite);
+        $furnitureContainer.add($text);
+
+        $furnitureContainer.on(DisplayObjectEvent.POINTER_TAP, () => {
+          System.events.emit(SystemEvent.CHAT_INPUT_APPEND_TEXT, furniture.id);
+          return;
+        });
       }
-
-      const $furnitureContainer = container({
-        size: {
-          width: size.width,
-          height: bounds.height + padding,
-        },
-        position: {
-          x: 0,
-          y: currentY,
-        },
-        eventMode: EventMode.STATIC,
-        cursor: Cursor.POINTER,
-      });
-
-      $furnitureList.add($furnitureContainer);
-
-      const $sprite = sprite({
-        spriteSheet: spriteSheet,
-        texture: texture,
-        position: {
-          x: 0,
-          y: 0,
-        },
-        bounds: bounds,
-        pivot: {
-          x: 0,
-          y: 0,
-        },
-        eventMode: EventMode.STATIC,
-        cursor: Cursor.POINTER,
-      });
-
-      const $text = textSprite({
-        text: furniture.id,
-        spriteSheet: SpriteSheetEnum.DEFAULT_FONT,
-        color: 0,
-        position: {
-          x: Math.max(30, bounds.width + 5),
-          y: bounds.height / 2 - 2,
-        },
-        eventMode: EventMode.STATIC,
-        cursor: Cursor.POINTER,
-      });
-
-      currentY += bounds.height + padding;
-      $furnitureContainer.add($sprite);
-      $furnitureContainer.add($text);
-
-      $furnitureContainer.on(DisplayObjectEvent.POINTER_TAP, () => {
-        System.events.emit(SystemEvent.CHAT_INPUT_APPEND_TEXT, furniture.id);
-        return;
-      });
     }
     $container.remove($loadingText);
   };

--- a/app/client/src/modules/interfaces/catalog/catalog-section.component.ts
+++ b/app/client/src/modules/interfaces/catalog/catalog-section.component.ts
@@ -99,81 +99,78 @@ export const catalogSectionComponent: ContainerComponent<Props> = (props) => {
       ...catalogFurniture.map((furniture) => furniture.id),
     );
 
-    // TODO - remove for loop once we check the fix works
-    for (let i = 0; i < 20; i++) {
-      for (const furniture of catalogFurniture) {
-        const { id, price } = furniture;
+    for (const furniture of catalogFurniture) {
+      const { id, price } = furniture;
 
-        const furnitureData = System.game.furniture.get(id);
+      const furnitureData = System.game.furniture.get(id);
 
-        const textures = Object.keys(
-          global.spriteSheets.get(furnitureData.spriteSheet).textures,
-        );
+      const textures = Object.keys(
+        global.spriteSheets.get(furnitureData.spriteSheet).textures,
+      );
 
-        let { texture, bounds } = furnitureData.icon;
-        let spriteSheet = furnitureData.spriteSheet;
+      let { texture, bounds } = furnitureData.icon;
+      let spriteSheet = furnitureData.spriteSheet;
 
-        if (!textures.includes(texture)) {
-          await System.game.furniture.loadFurniture(DEFAULT_FURNITURE);
-          const defaultSpriteSheetObject =
-            System.game.furniture.get(DEFAULT_FURNITURE);
-          texture = defaultSpriteSheetObject.icon.texture;
-          bounds = defaultSpriteSheetObject.icon.bounds;
-          spriteSheet = defaultSpriteSheetObject.spriteSheet;
-        }
-
-        const $furnitureContainer = container({
-          size: {
-            width: size.width,
-            height: bounds.height + padding,
-          },
-          position: {
-            x: 0,
-            y: currentY,
-          },
-          eventMode: EventMode.STATIC,
-          cursor: Cursor.POINTER,
-        });
-
-        $furnitureList.add($furnitureContainer);
-
-        const $sprite = sprite({
-          spriteSheet: spriteSheet,
-          texture: texture,
-          position: {
-            x: 0,
-            y: 0,
-          },
-          bounds: bounds,
-          pivot: {
-            x: 0,
-            y: 0,
-          },
-          eventMode: EventMode.STATIC,
-          cursor: Cursor.POINTER,
-        });
-
-        const $text = textSprite({
-          text: furniture.id,
-          spriteSheet: SpriteSheetEnum.DEFAULT_FONT,
-          color: 0,
-          position: {
-            x: Math.max(30, bounds.width + 5),
-            y: bounds.height / 2 - 2,
-          },
-          eventMode: EventMode.STATIC,
-          cursor: Cursor.POINTER,
-        });
-
-        currentY += bounds.height + padding;
-        $furnitureContainer.add($sprite);
-        $furnitureContainer.add($text);
-
-        $furnitureContainer.on(DisplayObjectEvent.POINTER_TAP, () => {
-          System.events.emit(SystemEvent.CHAT_INPUT_APPEND_TEXT, furniture.id);
-          return;
-        });
+      if (!textures.includes(texture)) {
+        await System.game.furniture.loadFurniture(DEFAULT_FURNITURE);
+        const defaultSpriteSheetObject =
+          System.game.furniture.get(DEFAULT_FURNITURE);
+        texture = defaultSpriteSheetObject.icon.texture;
+        bounds = defaultSpriteSheetObject.icon.bounds;
+        spriteSheet = defaultSpriteSheetObject.spriteSheet;
       }
+
+      const $furnitureContainer = container({
+        size: {
+          width: size.width,
+          height: bounds.height + padding,
+        },
+        position: {
+          x: 0,
+          y: currentY,
+        },
+        eventMode: EventMode.STATIC,
+        cursor: Cursor.POINTER,
+      });
+
+      $furnitureList.add($furnitureContainer);
+
+      const $sprite = sprite({
+        spriteSheet: spriteSheet,
+        texture: texture,
+        position: {
+          x: 0,
+          y: 0,
+        },
+        bounds: bounds,
+        pivot: {
+          x: 0,
+          y: 0,
+        },
+        eventMode: EventMode.STATIC,
+        cursor: Cursor.POINTER,
+      });
+
+      const $text = textSprite({
+        text: furniture.id,
+        spriteSheet: SpriteSheetEnum.DEFAULT_FONT,
+        color: 0,
+        position: {
+          x: Math.max(30, bounds.width + 5),
+          y: bounds.height / 2 - 2,
+        },
+        eventMode: EventMode.STATIC,
+        cursor: Cursor.POINTER,
+      });
+
+      currentY += bounds.height + padding;
+      $furnitureContainer.add($sprite);
+      $furnitureContainer.add($text);
+
+      $furnitureContainer.on(DisplayObjectEvent.POINTER_TAP, () => {
+        System.events.emit(SystemEvent.CHAT_INPUT_APPEND_TEXT, furniture.id);
+        return;
+      });
     }
     $container.remove($loadingText);
   };

--- a/app/client/src/modules/interfaces/navigator/navigator-modal.component.ts
+++ b/app/client/src/modules/interfaces/navigator/navigator-modal.component.ts
@@ -136,9 +136,15 @@ export const navigatorModalComponent: ContainerComponent<Props> = (
         SpriteSheetEnum.NAVIGATOR,
       );
 
-      $content.remove(categoryComponentMap[selectedCategory]);
+      categoryComponentMap[selectedCategory].setVisible(false);
       selectedCategory = categoryIndex;
-      $content.add(categoryComponentMap[selectedCategory]);
+      const isAlreadyAdded = $content
+        .getChildren()
+        .includes(categoryComponentMap[selectedCategory]);
+      if (!isAlreadyAdded) {
+        $content.add(categoryComponentMap[selectedCategory]);
+      }
+      categoryComponentMap[selectedCategory].setVisible(true);
     });
     const tabItemTexture = sprite({
       spriteSheet: SpriteSheetEnum.NAVIGATOR,


### PR DESCRIPTION
I'll draft the PR for the moment just to see if this fixes the memory leak.

Now instead of removing/adding the components all the time, I simply add and change the visibility to remove (and add if it's already added). Check with a profiler for any memory leaks.

I also added a for loop to add x20 more furnitures to make the memory leak more apparent, and the lag when opening the tabs does not incrase (no memory leak(?)).

With the x20 furniture I've also seen that rendering the tab takes a lot of time rendering and it blocks the whole application, but it's not related with the memory leak issue.