### PR TITLE
fix: calculate contributors order first by creator, then by contributions - #fix 536

### DIFF
--- a/app/client/src/system/contributors.ts
+++ b/app/client/src/system/contributors.ts
@@ -13,11 +13,10 @@ export const contributors = () => {
           ...contributor,
           creator: OWNER_LIST.includes(contributor.login),
         }))
-        .sort((contributorA: Contributor, contributorB: Contributor) =>
-          contributorA.contributions > contributorB.contributions ||
-          contributorA.creator
-            ? -1
-            : 1,
+        .sort(
+          (contributorA: Contributor, contributorB: Contributor) =>
+            Number(contributorB.creator) - Number(contributorA.creator) ||
+            contributorB.contributions - contributorA.contributions,
         );
     } catch (e) {
       contributors = DEFAULT_CONTRIBUTOR_LIST;


### PR DESCRIPTION
First compare creator, and the contributions. If both contributors have the same .creator, the first conditions returns 0 (falsy in JS/TS), so it checks then the second conditions, the contributions.