### PR TITLE
feat: add demo command - fix #439

### DIFF
--- a/app/server/assets/locales/en.json
+++ b/app/server/assets/locales/en.json
@@ -24,11 +24,11 @@
   "{{command}}: {{description}}": "{{command}}: {{description}}",
   "No description available": "No description available",
   "Invalid arguments. None of the following usages matched: {{usages}}": "Invalid arguments. None of the following usages matched: {{usages}}",
-  "You don't have permission to use this command": "You don't have permission to use this command",
 
   "command.ban.description": "Bans a user",
   "command.blacklist.description": "Manages the blacklist",
   "command.clear.description": "Clears all furnitures from the room",
+  "command.demo.description": "Populates Room 1 with many furniture",
   "command.deop.description": "Revokes operator status from a user",
   "command.help.description": "Shows a list of available commands or information about a specific command",
   "command.kick.description": "Kicks a user",

--- a/app/server/assets/locales/en.json
+++ b/app/server/assets/locales/en.json
@@ -24,6 +24,7 @@
   "{{command}}: {{description}}": "{{command}}: {{description}}",
   "No description available": "No description available",
   "Invalid arguments. None of the following usages matched: {{usages}}": "Invalid arguments. None of the following usages matched: {{usages}}",
+  "You don't have permission to use this command": "You don't have permission to use this command",
 
   "command.ban.description": "Bans a user",
   "command.blacklist.description": "Manages the blacklist",

--- a/app/server/assets/locales/es.json
+++ b/app/server/assets/locales/es.json
@@ -28,7 +28,7 @@
   "command.ban.description": "Banea a un usuario",
   "command.blacklist.description": "Administra la lista negra",
   "command.clear.description": "Elimina todos los muebles de la sala",
-  "command.demo.description": "Puebl la Room 1 con muchos muebles",
+  "command.demo.description": "Puebla la Room 1 con muchos muebles",
   "command.deop.description": "Revoca el estado de operador a un usuario",
   "command.help.description": "Muestra una lista de comandos disponibles o información sobre un comando específico",
   "command.kick.description": "Expulsa a un usuario",

--- a/app/server/assets/locales/es.json
+++ b/app/server/assets/locales/es.json
@@ -28,6 +28,7 @@
   "command.ban.description": "Banea a un usuario",
   "command.blacklist.description": "Administra la lista negra",
   "command.clear.description": "Elimina todos los muebles de la sala",
+  "command.demo.description": "Puebl la Room 1 con muchos muebles",
   "command.deop.description": "Revoca el estado de operador a un usuario",
   "command.help.description": "Muestra una lista de comandos disponibles o información sobre un comando específico",
   "command.kick.description": "Expulsa a un usuario",

--- a/app/server/src/modules/system/commands/demo.command.ts
+++ b/app/server/src/modules/system/commands/demo.command.ts
@@ -1,0 +1,117 @@
+import { System } from "../main.ts";
+import { Command, RoomFurniture } from "shared/types/main.ts";
+import { FurnitureType, ProxyEvent } from "shared/enums/main.ts";
+import { CrossDirection } from "@oh/utils";
+
+export const demoCommand: Command = {
+  command: "demo",
+  usages: ["[true|false]"],
+  description: "command.demo.description",
+  func: async ({ user, args }) => {
+    const room1 = await System.game.rooms.getByName("Room 1");
+
+    if (!room1) return;
+
+    // Mock furniture data
+    const mockFurnitureData = [
+      {
+        furnitureId: "alpha@small-lamp",
+        type: FurnitureType.FURNITURE,
+        position: { x: 1, y: 0, z: 7 },
+        direction: CrossDirection.NORTH,
+      },
+      {
+        furnitureId: "alpha@mid-lamp",
+        type: FurnitureType.FURNITURE,
+        position: { x: 2, y: 0, z: 7 },
+        direction: CrossDirection.NORTH,
+      },
+      {
+        furnitureId: "alpha@p-24",
+        type: FurnitureType.FRAME,
+        position: { x: 1, y: 0, z: 7 },
+        direction: CrossDirection.NORTH,
+        framePosition: { x: 0, y: 30 },
+      },
+      {
+        furnitureId: "toys@octopus-0",
+        type: FurnitureType.FURNITURE,
+        position: { x: 3, y: 0, z: 5 },
+        direction: CrossDirection.NORTH,
+      },
+      {
+        furnitureId: "xmas@tree-0",
+        type: FurnitureType.FURNITURE,
+        position: { x: 6, y: -1, z: 9 },
+        direction: CrossDirection.NORTH,
+      },
+      {
+        furnitureId: "xmas@tree-1",
+        type: FurnitureType.FURNITURE,
+        position: { x: 7, y: -1, z: 9 },
+        direction: CrossDirection.NORTH,
+      },
+      {
+        furnitureId: "flags@pride-trans",
+        type: FurnitureType.FRAME,
+        position: { x: 4, y: 0, z: 3 },
+        direction: CrossDirection.EAST,
+        framePosition: { x: 0, y: 35 },
+      },
+      {
+        furnitureId: "flags@europe",
+        type: FurnitureType.FRAME,
+        position: { x: 4, y: 0, z: 3 },
+        direction: CrossDirection.EAST,
+        framePosition: { x: 0, y: 15 },
+      },
+      {
+        furnitureId: "teleports@telephone",
+        type: FurnitureType.TELEPORT,
+        position: { x: 1, y: 0, z: 3 },
+        direction: CrossDirection.EAST,
+      },
+      {
+        furnitureId: "teleports@telephone",
+        type: FurnitureType.TELEPORT,
+        position: { x: 6, y: -1, z: 0 },
+        direction: CrossDirection.NORTH,
+      },
+    ];
+
+    const addedFurniture: RoomFurniture[] = [];
+
+    for (const data of mockFurnitureData) {
+      const $furniture = await System.game.furniture.get(data.furnitureId);
+
+      const furniture: RoomFurniture = {
+        furnitureId: data.furnitureId,
+        type: $furniture.type,
+        id: crypto.randomUUID(),
+        direction: data.direction,
+        position: data.position,
+      };
+
+      if (furniture.type === FurnitureType.FRAME) {
+        furniture.framePosition = data.framePosition;
+      }
+
+      if (furniture.type === FurnitureType.TELEPORT) {
+        await System.game.teleports.setRoom(furniture.id, room1.getId());
+      }
+
+      await room1.addFurniture(furniture);
+      room1.emit(ProxyEvent.ADD_FURNITURE, { furniture });
+      addedFurniture.push(furniture);
+    }
+
+    const teleports = addedFurniture.filter(
+      (f) => f.type === FurnitureType.TELEPORT,
+    );
+
+    if (teleports.length >= 2) {
+      const [teleportA, teleportB] = teleports;
+      await System.game.teleports.setLink(teleportA.id, teleportB.id);
+    }
+  },
+};

--- a/app/server/src/modules/system/commands/demo.command.ts
+++ b/app/server/src/modules/system/commands/demo.command.ts
@@ -5,7 +5,7 @@ import { CrossDirection } from "@oh/utils";
 
 export const demoCommand: Command = {
   command: "demo",
-  usages: ["[true|false]"],
+  usages: [""],
   description: "command.demo.description",
   func: async ({ user, args }) => {
     const room1 = await System.game.rooms.getByName("Room 1");

--- a/app/server/src/modules/system/commands/main.ts
+++ b/app/server/src/modules/system/commands/main.ts
@@ -19,6 +19,7 @@ import { teleportCommand } from "./teleport.command.ts";
 import { clearCommand } from "./clear.command.ts";
 import { rotateCommand } from "./rotate.command.ts";
 import { moveCommand } from "./move.command.ts";
+import { demoCommand } from "./demo.command.ts";
 import { ProxyEvent } from "shared/enums/event.enum.ts";
 import { validateCommandUsages } from "shared/utils/commands.utils.ts";
 import { __ } from "shared/utils/languages.utils.ts";
@@ -44,6 +45,7 @@ export const commandList = [
   unsetCommand,
 
   helpCommand,
+  demoCommand,
 
   teleportCommand,
 

--- a/app/server/src/modules/system/game/rooms.ts
+++ b/app/server/src/modules/system/game/rooms.ts
@@ -290,6 +290,11 @@ export const rooms = () => {
     );
   };
 
+  const getByName = async (name: string): Promise<RoomMutable | null> => {
+    const roomList = await getList();
+    return roomList.find((room) => room.getTitle() === name) || null;
+  };
+
   const getRandom = async (): Promise<RoomMutable> => {
     const roomList = await getList();
     const roomIndex = getRandomNumber(0, roomList.length - 1);
@@ -299,6 +304,7 @@ export const rooms = () => {
   return {
     get,
     getList,
+    getByName,
 
     getRandom,
   };


### PR DESCRIPTION
Using `/demo` command , creates most of the available furniture in Room 1. The idea is to hardcore the heck out of this command to showcase a fully furnitured room. Also links both teleports.

![image](https://github.com/user-attachments/assets/449c407e-f945-4f6a-82a3-961e156a1940)