### PR TITLE
fix: allow touchevents to stop dragging - fix #648

### DIFF
--- a/app/client/src/modules/scenes/private-room/private-room.component.ts
+++ b/app/client/src/modules/scenes/private-room/private-room.component.ts
@@ -165,7 +165,10 @@ export const privateRoomComponent: ContainerComponent<
     });
 
     onRemovePointerUp = global.events.on(TulipEvent.POINTER_UP, (event) => {
-      if (event instanceof MouseEvent && event.button == 0 || event instanceof TouchEvent) {
+      if (
+        (event instanceof MouseEvent && event.button == 0) ||
+        event instanceof TouchEvent
+      ) {
         isDragging = false;
       }
     });

--- a/app/client/src/modules/scenes/private-room/private-room.component.ts
+++ b/app/client/src/modules/scenes/private-room/private-room.component.ts
@@ -165,9 +165,9 @@ export const privateRoomComponent: ContainerComponent<
     });
 
     onRemovePointerUp = global.events.on(TulipEvent.POINTER_UP, (event) => {
-      System.events.emit(SystemEvent.TEST, `pointer up ${event.button}`);
-      if (event.button !== 0) return;
-      isDragging = false;
+      if (event instanceof MouseEvent && event.button == 0 || event instanceof TouchEvent) {
+        isDragging = false;
+      }
     });
 
     System.events.emit(SystemEvent.HIDE_NAVIGATOR_MODAL);


### PR DESCRIPTION
No need to check further TouchEvent attributes since we already know it's a POINTER_UP (and TouchEvents don't have metadata about the click, since touch devices only have '1 button')