### PR TITLE
feat: Detect wall positions with cursor - fix #677

### DIFF
--- a/app/client/src/modules/scenes/private-room/room.component.ts
+++ b/app/client/src/modules/scenes/private-room/room.component.ts
@@ -236,6 +236,7 @@ export const roomComponent: ContainerComponent<Props, RoomMutable> = (
               position: wallPosition,
               tint: 0xc4d3dd,
               height: wallHeight,
+              point: { x, y, z },
             });
             $container.add(wall);
           }
@@ -247,6 +248,7 @@ export const roomComponent: ContainerComponent<Props, RoomMutable> = (
               position: wallPosition,
               tint: 0xc4d3dd,
               height: wallHeight,
+              point: { x, y, z },
             });
             $container.add(wall);
           }
@@ -271,6 +273,7 @@ export const roomComponent: ContainerComponent<Props, RoomMutable> = (
               position,
               tint: 0xc4d3dd,
               height: WALL_DOOR_HEIGHT,
+              point: { x, y, z },
             });
             $container.add(wall);
           }
@@ -282,6 +285,7 @@ export const roomComponent: ContainerComponent<Props, RoomMutable> = (
               position,
               tint: 0xc4d3dd,
               height: WALL_DOOR_HEIGHT,
+              point: { x, y, z },
             });
             $container.add(wall);
           }


### PR DESCRIPTION
This PR enables cursor detection of wall tile positions in private rooms. It resolves [issue #677](https://github.com/openhotel/openhotel/issues/677)

### Summary of changes

- **Added `point` prop** to the `wallComponent`, enabling positional context.
- Updated wall sprites (`top`, `mid`, `bottom`) to:
  - Use `EventMode.STATIC` and show pointer cursor when `point` is present.
  - Emit `SystemEvent.CURSOR_COORDS` on pointer hover.
  - Emit `Event.POINTER_TILE` on pointer click, passing the wall's `point`.
- Updated `room.component.ts` to pass `point` to all `wallComponent` instances.

### Tests

1. Enter a private room.
2. Hover over a wall tile — the system should emit `CURSOR_COORDS`.
3. Click on a wall — the system should emit `POINTER_TILE` with the correct `{ x, z }` coordinates.
4. Character should **walk to the wall** on click.

- Walls are now conditionally interactive, depending on whether `point` is defined.