### PR TITLE
feat: add camera movement in rooms - fix #720

### DIFF
--- a/app/client/src/modules/application/application.component.tsx
+++ b/app/client/src/modules/application/application.component.tsx
@@ -13,6 +13,7 @@ import {
   TasksProvider,
   PrivateRoomProvider,
   RouterProviderWrapper,
+  CameraProvider,
 } from "shared/hooks";
 import { NesterComponent } from "shared/components";
 import { FurnitureProvider } from "shared/hooks";
@@ -30,6 +31,7 @@ export const ApplicationComponent = () => {
       AssetsProvider,
       CoreLoaderComponent,
       AccountProvider,
+      CameraProvider, // Before 'ModalProvider' so 'ModalProvider' can use 'useCamera'
       ModalProvider,
       RouterProvider,
       InfoProvider,

--- a/app/client/src/modules/modals/components/catalog/catalog.stories.tsx
+++ b/app/client/src/modules/modals/components/catalog/catalog.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from "@storybook/react";
 import React from "react";
-import { ModalProvider } from "shared/hooks";
+import { CameraProvider, ModalProvider } from "shared/hooks";
 import { CatalogComponent } from "./catalog.component";
 
 export default {
@@ -13,10 +13,13 @@ export default {
 
 type Story = StoryObj<typeof CatalogComponent>;
 
+//@ts-ignore
 export const Primary: Story = () => {
   return (
-    <ModalProvider>
-      <CatalogComponent />
-    </ModalProvider>
+    <CameraProvider>
+      <ModalProvider>
+        <CatalogComponent />
+      </ModalProvider>
+    </CameraProvider>
   );
 };

--- a/app/client/src/modules/modals/components/navigator/navigator.stories.tsx
+++ b/app/client/src/modules/modals/components/navigator/navigator.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta, StoryObj } from "@storybook/react";
 import React from "react";
 import { NavigatorComponentWrapper } from "./navigator.component";
-import { ModalProvider } from "shared/hooks";
+import { CameraProvider, ModalProvider } from "shared/hooks";
 import { DragContainerProvider } from "@openhotel/pixi-components";
 import { fn } from "@storybook/test";
 import { ModalNavigatorTab } from "shared/enums";
@@ -20,24 +20,26 @@ type Story = StoryObj<typeof NavigatorComponentWrapper>;
 //@ts-ignore
 export const Primary: Story = () => {
   return (
-    <ModalProvider>
-      <DragContainerProvider>
-        <NavigatorComponentWrapper
-          onPointerDown={fn()}
-          navigatorTabMap={
-            {
-              [ModalNavigatorTab.ROOMS]: () => (
-                <CategoryRoomsComponentWrapper
-                  rooms={[]}
-                  size={{ width: 10, height: 10 }}
-                  onClickFavorite={fn()}
-                  onClickGo={fn()}
-                />
-              ),
-            } as any
-          }
-        />
-      </DragContainerProvider>
-    </ModalProvider>
+    <CameraProvider>
+      <ModalProvider>
+        <DragContainerProvider>
+          <NavigatorComponentWrapper
+            onPointerDown={fn()}
+            navigatorTabMap={
+              {
+                [ModalNavigatorTab.ROOMS]: () => (
+                  <CategoryRoomsComponentWrapper
+                    rooms={[]}
+                    size={{ width: 10, height: 10 }}
+                    onClickFavorite={fn()}
+                    onClickGo={fn()}
+                  />
+                ),
+              } as any
+            }
+          />
+        </DragContainerProvider>
+      </ModalProvider>
+    </CameraProvider>
   );
 };

--- a/app/client/src/modules/private-room/private-room.component.tsx
+++ b/app/client/src/modules/private-room/private-room.component.tsx
@@ -46,7 +46,7 @@ export const PrivateRoomComponent: React.FC<Props> = () => {
 
   const { getAccount } = useAccount();
   const { setExtra } = useInfo();
-  const { emit } = useProxy();
+  const { on, emit } = useProxy();
   const { room, setSelectedPreview, selectedPreview } = usePrivateRoom();
   const { lastUpdate, update } = useUpdate();
 
@@ -263,10 +263,18 @@ export const PrivateRoomComponent: React.FC<Props> = () => {
       dragCurrentRef.current = null;
     });
 
+    const onRemoveDisableCameraMovement = on(
+      ProxyEvent.DISABLE_CAMERA_MOVEMENT,
+      () => {
+        isDraggingRef.current = false;
+      },
+    );
+
     return () => {
       onRemovePointerDown();
       onRemovePointerMove();
       onRemovePointerUp();
+      onRemoveDisableCameraMovement();
     };
   }, [onEvent, update, room]);
 

--- a/app/client/src/modules/private-room/private-room.component.tsx
+++ b/app/client/src/modules/private-room/private-room.component.tsx
@@ -69,7 +69,6 @@ export const PrivateRoomComponent: React.FC<Props> = () => {
     [Point3d, Point2d, CrossDirection] | [null, null]
   >([null, null]);
 
-  const isDraggingRef = useRef(false);
   const wasDraggingRef = useRef(false);
   const dragStartRef = useRef<Point2d | null>(null);
   const dragCurrentRef = useRef<Point2d | null>(null);
@@ -227,14 +226,13 @@ export const PrivateRoomComponent: React.FC<Props> = () => {
     const onRemovePointerDown = onEvent(Event.POINTER_DOWN, (e: MouseEvent) => {
       dragCurrentRef.current = { x: e.clientX, y: e.clientY };
       dragStartRef.current = { x: e.clientX, y: e.clientY };
-      isDraggingRef.current = true;
       wasDraggingRef.current = false;
     });
 
     const MOVEMENT_THRESHOLD = 5;
 
     const onRemovePointerMove = onEvent(Event.POINTER_MOVE, (e: MouseEvent) => {
-      if (!isDraggingRef.current || !dragCurrentRef.current) return;
+      if (!dragCurrentRef.current) return;
 
       const dx = e.clientX - dragCurrentRef.current.x;
       const dy = e.clientY - dragCurrentRef.current.y;
@@ -259,14 +257,13 @@ export const PrivateRoomComponent: React.FC<Props> = () => {
     });
 
     const onRemovePointerUp = onEvent(Event.POINTER_UP, () => {
-      isDraggingRef.current = false;
       dragCurrentRef.current = null;
     });
 
     const onRemoveDisableCameraMovement = on(
       ProxyEvent.DISABLE_CAMERA_MOVEMENT,
       () => {
-        isDraggingRef.current = false;
+        dragCurrentRef.current = null;
       },
     );
 

--- a/app/client/src/modules/private-room/private-room.component.tsx
+++ b/app/client/src/modules/private-room/private-room.component.tsx
@@ -6,7 +6,7 @@ import React, {
   useState,
 } from "react";
 import {
-  CameraContainer,
+  CameraComponent,
   PreviewTileData,
   PrivateRoomComponent as PrivateRoomComp,
 } from "shared/components";
@@ -20,7 +20,7 @@ import {
   useUpdate,
   useWindow,
 } from "@openhotel/pixi-components";
-import { useAccount, usePrivateRoom, useProxy } from "shared/hooks";
+import { useAccount, useCamera, usePrivateRoom, useProxy } from "shared/hooks";
 import { Point2d, Point3d, Size2d } from "shared/types";
 import {
   CrossDirection,
@@ -50,6 +50,7 @@ export const PrivateRoomComponent: React.FC<Props> = () => {
   const { emit } = useProxy();
   const { room, setSelectedPreview, selectedPreview } = usePrivateRoom();
   const { lastUpdate, update } = useUpdate();
+  const { isDragging, position: cameraPosition } = useCamera();
 
   const { on: onEvent } = useEvents();
   const { getSize } = useWindow();
@@ -156,12 +157,14 @@ export const PrivateRoomComponent: React.FC<Props> = () => {
 
   const onPointerTile = useCallback(
     (position: Point3d) => {
+      if (isDragging) return;
+
       emit(ProxyEvent.POINTER_TILE, {
         position,
       });
       setSelectedPreview(null);
     },
-    [emit, setSelectedPreview],
+    [emit, setSelectedPreview, isDragging],
   );
 
   const onHoverTile = useCallback(
@@ -182,16 +185,16 @@ export const PrivateRoomComponent: React.FC<Props> = () => {
   const messagesPivot = useMemo(
     () => ({
       x: roomPivot.x,
-      y: roomPosition.y,
+      y: roomPosition.y + cameraPosition.y,
     }),
-    [roomPosition, roomPivot],
+    [roomPosition, roomPivot, cameraPosition],
   );
 
   if (!room) return null;
 
   return (
     <ContainerComponent>
-      <CameraContainer
+      <CameraComponent
         margin={100}
         contentRef={privateRoomRef}
         bottomPadding={HOT_BAR_HEIGHT_FULL}
@@ -217,7 +220,7 @@ export const PrivateRoomComponent: React.FC<Props> = () => {
         {/*  alpha={0.5}*/}
         {/*  eventMode={EventMode.NONE}*/}
         {/*/>*/}
-      </CameraContainer>
+      </CameraComponent>
       <ContainerComponent position={{ y: windowSize.height }}>
         <RoomInfoComponent />
         <ChatHotBarComponent width={windowSize.width} />

--- a/app/client/src/modules/private-room/private-room.component.tsx
+++ b/app/client/src/modules/private-room/private-room.component.tsx
@@ -191,34 +191,33 @@ export const PrivateRoomComponent: React.FC<Props> = () => {
 
   return (
     <ContainerComponent>
-			
-			<CameraContainer
-				margin={100}
-				contentRef={privateRoomRef}
-				bottomPadding={HOT_BAR_HEIGHT_FULL}
-			>
-      <ContainerComponent position={roomPosition}>
-        <PrivateRoomComp
-          ref={privateRoomRef}
-          {...room}
-          onPointerTile={onPointerTile}
-          onHoverTile={onHoverTile}
-          onClickWall={onClickWall}
-        >
-          <RoomCharactersComponent />
-          <RoomFurnitureComponent />
-        </PrivateRoomComp>
-        <RoomMessagesComponent pivot={messagesPivot} />
-      </ContainerComponent>
-      {/*<GraphicsComponent*/}
-      {/*  type={GraphicType.RECTANGLE}*/}
-      {/*  width={roomSize.width}*/}
-      {/*  height={roomSize.height}*/}
-      {/*  position={roomPosition}*/}
-      {/*  alpha={0.5}*/}
-      {/*  eventMode={EventMode.NONE}*/}
-      {/*/>*/}
-			</CameraContainer>
+      <CameraContainer
+        margin={100}
+        contentRef={privateRoomRef}
+        bottomPadding={HOT_BAR_HEIGHT_FULL}
+      >
+        <ContainerComponent position={roomPosition}>
+          <PrivateRoomComp
+            ref={privateRoomRef}
+            {...room}
+            onPointerTile={onPointerTile}
+            onHoverTile={onHoverTile}
+            onClickWall={onClickWall}
+          >
+            <RoomCharactersComponent />
+            <RoomFurnitureComponent />
+          </PrivateRoomComp>
+          <RoomMessagesComponent pivot={messagesPivot} />
+        </ContainerComponent>
+        {/*<GraphicsComponent*/}
+        {/*  type={GraphicType.RECTANGLE}*/}
+        {/*  width={roomSize.width}*/}
+        {/*  height={roomSize.height}*/}
+        {/*  position={roomPosition}*/}
+        {/*  alpha={0.5}*/}
+        {/*  eventMode={EventMode.NONE}*/}
+        {/*/>*/}
+      </CameraContainer>
       <ContainerComponent position={{ y: windowSize.height }}>
         <RoomInfoComponent />
         <ChatHotBarComponent width={windowSize.width} />

--- a/app/client/src/shared/components/camera/camera.component.tsx
+++ b/app/client/src/shared/components/camera/camera.component.tsx
@@ -1,0 +1,142 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import {
+  ContainerComponent,
+  Event,
+  useEvents,
+  useWindow,
+} from "@oh/pixi-components";
+import { Point2d } from "shared/types";
+import { useCamera } from "shared/hooks";
+
+type Props = {
+  children: React.ReactNode;
+  contentRef: React.RefObject<{
+    getSize: () => { width: number; height: number } | undefined;
+  }>;
+  margin?: number;
+  bottomPadding?: number;
+  onOffsetChange?: (offset: Point2d) => void;
+};
+
+export const CameraContainer: React.FC<Props> = ({
+  children,
+  contentRef,
+  margin = 50,
+  bottomPadding = 0,
+  onOffsetChange,
+}) => {
+  const { getSize } = useWindow();
+  const { on: onEvent } = useEvents();
+
+  const [windowSize, setWindowSize] = useState(getSize());
+  const [offset, setOffset] = useState<Point2d>({ x: 0, y: 0 });
+
+  const { setDragging, canDrag } = useCamera();
+  const canDragRef = useRef(canDrag);
+  useEffect(() => {
+    canDragRef.current = canDrag;
+  }, [canDrag]);
+
+  const dragStartRef = useRef<Point2d | null>(null);
+  const dragCurrentRef = useRef<Point2d | null>(null);
+  const wasDraggingRef = useRef(false);
+
+  useEffect(() => {
+    const onRemoveResize = onEvent(Event.RESIZE, () => {
+      setWindowSize(getSize());
+    });
+
+    setWindowSize(getSize());
+
+    return () => {
+      onRemoveResize();
+    };
+  }, [onEvent]);
+
+  useEffect(() => {
+    const MOVEMENT_THRESHOLD = 5;
+
+    const onRemovePointerDown = onEvent(
+      Event.POINTER_DOWN,
+      (e: MouseEvent | TouchEvent) => {
+        const { clientX: x, clientY: y } =
+          (e as TouchEvent).touches?.[0] ?? (e as MouseEvent);
+
+        dragCurrentRef.current = { x, y };
+        dragStartRef.current = { x, y };
+        wasDraggingRef.current = false;
+        setDragging(false);
+      },
+    );
+
+    const onRemovePointerMove = onEvent(
+      Event.POINTER_MOVE,
+      (e: MouseEvent | TouchEvent) => {
+        if (!dragCurrentRef.current || !canDragRef.current) {
+          dragCurrentRef.current = null;
+          dragStartRef.current = null;
+          return;
+        }
+
+        const { clientX: x, clientY: y } =
+          (e as TouchEvent).touches?.[0] ?? (e as MouseEvent);
+
+        const dx = x - dragCurrentRef.current.x;
+        const dy = y - dragCurrentRef.current.y;
+
+        setOffset((prev) => {
+          const next = { x: prev.x + dx, y: prev.y + dy };
+          onOffsetChange?.(next);
+          return next;
+        });
+
+        const totalDx = x - dragStartRef.current.x;
+        const totalDy = y - dragStartRef.current.y;
+
+        if (
+          Math.abs(totalDx) > MOVEMENT_THRESHOLD ||
+          Math.abs(totalDy) > MOVEMENT_THRESHOLD
+        ) {
+          setDragging(true);
+          wasDraggingRef.current = true;
+        }
+
+        dragCurrentRef.current = { x, y };
+      },
+    );
+
+    const onRemovePointerUp = onEvent(Event.POINTER_UP, () => {
+      dragCurrentRef.current = null;
+    });
+
+    return () => {
+      onRemovePointerDown();
+      onRemovePointerMove();
+      onRemovePointerUp();
+    };
+  }, [onEvent, onOffsetChange]);
+
+  const clampedPosition = useMemo(() => {
+    const contentSize = contentRef.current?.getSize?.();
+    if (!contentSize) return offset;
+
+    let minX = -contentSize.width / 2 + margin;
+    let maxX = contentSize.width / 2 - margin;
+    let minY = -contentSize.height / 2 + margin;
+    let maxY = contentSize.height / 2 - bottomPadding / 2 - margin;
+
+    const clampedX = Math.max(minX, Math.min(offset.x / 2, maxX));
+    const clampedY = Math.max(minY, Math.min(offset.y / 2, maxY));
+
+    return {
+      x: clampedX,
+      y: clampedY,
+    };
+  }, [offset, contentRef.current, windowSize, margin, bottomPadding]);
+
+  return (
+    <ContainerComponent position={clampedPosition}>
+      {children}
+    </ContainerComponent>
+  );
+};

--- a/app/client/src/shared/components/camera/camera.component.tsx
+++ b/app/client/src/shared/components/camera/camera.component.tsx
@@ -18,7 +18,7 @@ type Props = {
   onOffsetChange?: (offset: Point2d) => void;
 };
 
-export const CameraContainer: React.FC<Props> = ({
+export const CameraComponent: React.FC<Props> = ({
   children,
   contentRef,
   margin = 50,
@@ -31,15 +31,16 @@ export const CameraContainer: React.FC<Props> = ({
   const [windowSize, setWindowSize] = useState(getSize());
   const [offset, setOffset] = useState<Point2d>({ x: 0, y: 0 });
 
-  const { setDragging, canDrag } = useCamera();
+  const { setDragging, canDrag, setPosition } = useCamera();
   const canDragRef = useRef(canDrag);
-  useEffect(() => {
-    canDragRef.current = canDrag;
-  }, [canDrag]);
 
   const dragStartRef = useRef<Point2d | null>(null);
   const dragCurrentRef = useRef<Point2d | null>(null);
   const wasDraggingRef = useRef(false);
+
+  useEffect(() => {
+    canDragRef.current = canDrag;
+  }, [canDrag]);
 
   useEffect(() => {
     const onRemoveResize = onEvent(Event.RESIZE, () => {
@@ -133,6 +134,10 @@ export const CameraContainer: React.FC<Props> = ({
       y: clampedY,
     };
   }, [offset, contentRef.current, windowSize, margin, bottomPadding]);
+
+  useEffect(() => {
+    setPosition(clampedPosition);
+  }, [setPosition, clampedPosition]);
 
   return (
     <ContainerComponent position={clampedPosition}>

--- a/app/client/src/shared/components/camera/camera.component.tsx
+++ b/app/client/src/shared/components/camera/camera.component.tsx
@@ -4,7 +4,7 @@ import {
   Event,
   useEvents,
   useWindow,
-} from "@oh/pixi-components";
+} from "@openhotel/pixi-components";
 import { Point2d } from "shared/types";
 import { useCamera } from "shared/hooks";
 

--- a/app/client/src/shared/components/camera/index.ts
+++ b/app/client/src/shared/components/camera/index.ts
@@ -1,0 +1,1 @@
+export * from "./camera.component";

--- a/app/client/src/shared/components/hot-bar-items/hot-bar-items.stories.tsx
+++ b/app/client/src/shared/components/hot-bar-items/hot-bar-items.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from "@storybook/react";
 import { HotBarItemsComponent } from "./hot-bar-items.component";
 import { FlexContainerComponent } from "@openhotel/pixi-components";
 import React from "react";
-import { ModalProvider } from "shared/hooks";
+import { CameraProvider, ModalProvider } from "shared/hooks";
 
 export default {
   title: "Shared/Hot Bar Items",
@@ -17,10 +17,12 @@ type Story = StoryObj<typeof HotBarItemsComponent>;
 //@ts-ignore
 export const Primary: Story = () => {
   return (
-    <ModalProvider>
-      <FlexContainerComponent>
-        <HotBarItemsComponent />
-      </FlexContainerComponent>
-    </ModalProvider>
+    <CameraProvider>
+      <ModalProvider>
+        <FlexContainerComponent>
+          <HotBarItemsComponent />
+        </FlexContainerComponent>
+      </ModalProvider>
+    </CameraProvider>
   );
 };

--- a/app/client/src/shared/components/index.ts
+++ b/app/client/src/shared/components/index.ts
@@ -12,3 +12,4 @@ export * from "./furniture";
 export * from "./version";
 export * from "./info";
 export * from "./bubble-message";
+export * from "./camera";

--- a/app/client/src/shared/components/private-room/components/stairs/stairs.component.tsx
+++ b/app/client/src/shared/components/private-room/components/stairs/stairs.component.tsx
@@ -26,6 +26,7 @@ export const PrivateRoomStairs: React.FC<Props> = ({
   position,
   direction,
   onPointerDown,
+  onPointerUp,
   onPointerEnter,
   onPointerLeave,
 }) => {
@@ -59,6 +60,7 @@ export const PrivateRoomStairs: React.FC<Props> = ({
           x: direction === CrossDirection.NORTH ? 1 : -1,
         }}
         onPointerDown={onPointerDown}
+        onPointerUp={onPointerUp}
         onPointerEnter={onPointerEnter}
         onPointerLeave={onPointerLeave}
       />

--- a/app/client/src/shared/components/private-room/components/tile/tile.component.tsx
+++ b/app/client/src/shared/components/private-room/components/tile/tile.component.tsx
@@ -30,6 +30,7 @@ export const PrivateRoomTile: React.FC<Props> = ({
   position,
   spawn,
   onPointerDown,
+  onPointerUp,
   onPointerEnter,
   onPointerLeave,
   color,
@@ -56,6 +57,7 @@ export const PrivateRoomTile: React.FC<Props> = ({
         tint={0xcccc00}
         alpha={0}
         onPointerDown={onPointerDown}
+        onPointerUp={onPointerUp}
         onPointerEnter={onPointerEnter}
         onPointerLeave={onPointerLeave}
       />

--- a/app/client/src/shared/components/private-room/private-room.component.tsx
+++ b/app/client/src/shared/components/private-room/private-room.component.tsx
@@ -123,7 +123,7 @@ export const PrivateRoomComponent: React.FC<Props> = ({
               key={`stairs${x}.${z}`}
               position={position}
               direction={stairsDirection}
-              onPointerDown={() => onPointerTile?.(position)}
+              onPointerUp={() => onPointerTile?.(position)}
               onPointerEnter={() =>
                 $onHoverTile({
                   point: position,
@@ -138,7 +138,7 @@ export const PrivateRoomComponent: React.FC<Props> = ({
               key={`tile${x}.${z}`}
               spawn={spawn}
               position={position}
-              onPointerDown={() => onPointerTile?.(position)}
+							onPointerUp={() => onPointerTile?.(position)}
               onPointerEnter={() =>
                 $onHoverTile({ point: position, type: "tile" })
               }

--- a/app/client/src/shared/components/private-room/private-room.component.tsx
+++ b/app/client/src/shared/components/private-room/private-room.component.tsx
@@ -6,11 +6,7 @@ import React, {
   useRef,
   useState,
 } from "react";
-import {
-  ContainerComponent,
-  ContainerRef,
-  EventMode,
-} from "@openhotel/pixi-components";
+import { ContainerComponent, ContainerRef } from "@openhotel/pixi-components";
 import { CrossDirection, RoomPointEnum } from "shared/enums";
 import {
   getPositionFromIsometricPosition,
@@ -25,7 +21,6 @@ import {
   PrivateRoomTilePreview,
   PrivateRoomWallComponent,
 } from "./components";
-import { useCamera } from "shared/hooks";
 
 type Props = {
   ref?: React.Ref<ContainerRef>;
@@ -56,13 +51,6 @@ export const PrivateRoomComponent: React.FC<Props> = ({
   const $ref = useRef<ContainerRef>(null);
   const $sizeRef = useRef<ContainerRef>(null);
 
-  const { isDragging } = useCamera();
-  const isDraggingRef = useRef(isDragging);
-
-  useEffect(() => {
-    isDraggingRef.current = isDragging;
-  }, [isDragging]);
-
   const [rawRoomSize, setRawRoomSize] = useState<Size2d>({
     width: 0,
     height: 0,
@@ -75,14 +63,6 @@ export const PrivateRoomComponent: React.FC<Props> = ({
       setPreviewData(data);
     },
     [onHoverTile, setPreviewData],
-  );
-
-  const $onPointerTile = useCallback(
-    (point: Point3d) => {
-      if (isDraggingRef.current) return;
-      onPointerTile?.(point);
-    },
-    [onPointerTile, isDragging],
   );
 
   ref &&
@@ -143,7 +123,7 @@ export const PrivateRoomComponent: React.FC<Props> = ({
               key={`stairs${x}.${z}`}
               position={position}
               direction={stairsDirection}
-              onPointerUp={() => $onPointerTile?.(position)}
+              onPointerUp={() => onPointerTile?.(position)}
               onPointerEnter={() =>
                 $onHoverTile({
                   point: position,
@@ -158,7 +138,7 @@ export const PrivateRoomComponent: React.FC<Props> = ({
               key={`tile${x}.${z}`}
               spawn={spawn}
               position={position}
-              onPointerUp={() => $onPointerTile?.(position)}
+              onPointerUp={() => onPointerTile?.(position)}
               onPointerEnter={() =>
                 $onHoverTile({ point: position, type: "tile" })
               }
@@ -246,7 +226,7 @@ export const PrivateRoomComponent: React.FC<Props> = ({
     }
 
     return [list, accumulatedPivot];
-  }, [layout, $onPointerTile, $onHoverTile]);
+  }, [layout, onPointerTile, $onHoverTile]);
 
   useEffect(() => {
     setRawRoomSize((size) => $sizeRef?.current?.getSize?.() ?? size);

--- a/app/client/src/shared/components/private-room/private-room.component.tsx
+++ b/app/client/src/shared/components/private-room/private-room.component.tsx
@@ -6,7 +6,11 @@ import React, {
   useRef,
   useState,
 } from "react";
-import { ContainerComponent, ContainerRef, EventMode } from "@openhotel/pixi-components";
+import {
+  ContainerComponent,
+  ContainerRef,
+  EventMode,
+} from "@openhotel/pixi-components";
 import { CrossDirection, RoomPointEnum } from "shared/enums";
 import {
   getPositionFromIsometricPosition,
@@ -72,14 +76,14 @@ export const PrivateRoomComponent: React.FC<Props> = ({
     },
     [onHoverTile, setPreviewData],
   );
-	
-	const $onPointerTile = useCallback(
-		(point: Point3d) => {
-			if (isDraggingRef.current) return;
-			onPointerTile?.(point);
-		},
-		[onPointerTile, isDragging],
-	);
+
+  const $onPointerTile = useCallback(
+    (point: Point3d) => {
+      if (isDraggingRef.current) return;
+      onPointerTile?.(point);
+    },
+    [onPointerTile, isDragging],
+  );
 
   ref &&
     useImperativeHandle(
@@ -154,7 +158,7 @@ export const PrivateRoomComponent: React.FC<Props> = ({
               key={`tile${x}.${z}`}
               spawn={spawn}
               position={position}
-							onPointerUp={() => $onPointerTile?.(position)}
+              onPointerUp={() => $onPointerTile?.(position)}
               onPointerEnter={() =>
                 $onHoverTile({ point: position, type: "tile" })
               }

--- a/app/client/src/shared/components/private-room/private-room.stories.tsx
+++ b/app/client/src/shared/components/private-room/private-room.stories.tsx
@@ -66,6 +66,8 @@ export const Primary: Story = () => {
     />
   );
 };
+
+//@ts-ignore
 export const Simple: Story = () => {
   const layout = [
     "x1111111",
@@ -99,11 +101,14 @@ export const Simple: Story = () => {
         maxUsers: 10,
         ownerId: "test",
         ownerUsername: "test",
+        users: [],
       }}
       onPointerTile={console.log}
     />
   );
 };
+
+//@ts-ignore
 export const Stairs: Story = () => {
   const layout = [
     "xxxxxxxx11",
@@ -149,11 +154,14 @@ export const Stairs: Story = () => {
         maxUsers: 10,
         ownerId: "test",
         ownerUsername: "test",
+        users: [],
       }}
       onPointerTile={console.log}
     />
   );
 };
+
+//@ts-ignore
 export const Stairs1: Story = () => {
   const layout = [
     "xxxxxxxx11",
@@ -193,6 +201,7 @@ export const Stairs1: Story = () => {
           maxUsers: 10,
           ownerId: "test",
           ownerUsername: "test",
+          users: [],
         }}
         onPointerTile={console.log}
       />

--- a/app/client/src/shared/enums/event.enums.ts
+++ b/app/client/src/shared/enums/event.enums.ts
@@ -36,4 +36,6 @@ export enum Event {
 
   CONNECTED = "connected",
   DISCONNECTED = "disconnected",
+
+  DISABLE_CAMERA_MOVEMENT = "disable-camera-movement",
 }

--- a/app/client/src/shared/hooks/camera/camera.context.tsx
+++ b/app/client/src/shared/hooks/camera/camera.context.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+
+export type CameraState = {
+  isDragging: boolean;
+  canDrag: boolean;
+  setDragging: (dragging: boolean) => void;
+  setCanDrag: (canDrag: boolean) => void;
+};
+
+export const CameraContext = React.createContext<CameraState | undefined>(
+  undefined,
+);

--- a/app/client/src/shared/hooks/camera/camera.context.tsx
+++ b/app/client/src/shared/hooks/camera/camera.context.tsx
@@ -1,10 +1,13 @@
 import React from "react";
+import { Point2d } from "shared/types";
 
 export type CameraState = {
   isDragging: boolean;
   canDrag: boolean;
+  position: Point2d;
   setDragging: (dragging: boolean) => void;
   setCanDrag: (canDrag: boolean) => void;
+  setPosition: (position: Point2d) => void;
 };
 
 export const CameraContext = React.createContext<CameraState | undefined>(

--- a/app/client/src/shared/hooks/camera/camera.provider.tsx
+++ b/app/client/src/shared/hooks/camera/camera.provider.tsx
@@ -1,6 +1,7 @@
 import React, { ReactNode, useCallback } from "react";
 import { CameraContext } from "./camera.context";
 import { useCameraStore } from "./camera.store";
+import { Point2d } from "shared/types";
 
 type CameraProviderProps = {
   children: ReactNode;
@@ -10,8 +11,10 @@ export const CameraProvider: React.FC<CameraProviderProps> = ({ children }) => {
   const {
     isDragging,
     canDrag,
+    position,
     setDragging: $setDragging,
     setCanDrag: $setCanDrag,
+    setPosition: $setPosition,
   } = useCameraStore();
 
   const setDragging = useCallback(
@@ -24,13 +27,20 @@ export const CameraProvider: React.FC<CameraProviderProps> = ({ children }) => {
     [$setCanDrag],
   );
 
+  const setPosition = useCallback(
+    (position: Point2d) => $setPosition(position),
+    [$setPosition],
+  );
+
   return (
     <CameraContext.Provider
       value={{
         isDragging,
         canDrag,
+        position,
         setDragging,
         setCanDrag,
+        setPosition,
       }}
     >
       {children}

--- a/app/client/src/shared/hooks/camera/camera.provider.tsx
+++ b/app/client/src/shared/hooks/camera/camera.provider.tsx
@@ -1,0 +1,39 @@
+import React, { ReactNode, useCallback } from "react";
+import { CameraContext } from "./camera.context";
+import { useCameraStore } from "./camera.store";
+
+type CameraProviderProps = {
+  children: ReactNode;
+};
+
+export const CameraProvider: React.FC<CameraProviderProps> = ({ children }) => {
+  const {
+    isDragging,
+    canDrag,
+    setDragging: $setDragging,
+    setCanDrag: $setCanDrag,
+  } = useCameraStore();
+
+  const setDragging = useCallback(
+    (dragging: boolean) => $setDragging(dragging),
+    [$setDragging],
+  );
+
+  const setCanDrag = useCallback(
+    (canDrag: boolean) => $setCanDrag(canDrag),
+    [$setCanDrag],
+  );
+
+  return (
+    <CameraContext.Provider
+      value={{
+        isDragging,
+        canDrag,
+        setDragging,
+        setCanDrag,
+      }}
+    >
+      {children}
+    </CameraContext.Provider>
+  );
+};

--- a/app/client/src/shared/hooks/camera/camera.store.ts
+++ b/app/client/src/shared/hooks/camera/camera.store.ts
@@ -1,15 +1,20 @@
 import { create } from "zustand";
+import { Point2d } from "shared/types";
 
 type CameraState = {
   isDragging: boolean;
   canDrag: boolean;
+  position: Point2d;
   setDragging: (dragging: boolean) => void;
   setCanDrag: (canDrag: boolean) => void;
+  setPosition: (position: Point2d) => void;
 };
 
 export const useCameraStore = create<CameraState>((set) => ({
   isDragging: false,
   canDrag: true,
+  position: { x: 0, y: 0 },
   setDragging: (isDragging) => set({ isDragging }),
   setCanDrag: (canDrag) => set({ canDrag }),
+  setPosition: (position) => set({ position }),
 }));

--- a/app/client/src/shared/hooks/camera/camera.store.ts
+++ b/app/client/src/shared/hooks/camera/camera.store.ts
@@ -1,0 +1,15 @@
+import { create } from "zustand";
+
+type CameraState = {
+  isDragging: boolean;
+  canDrag: boolean;
+  setDragging: (dragging: boolean) => void;
+  setCanDrag: (canDrag: boolean) => void;
+};
+
+export const useCameraStore = create<CameraState>((set) => ({
+  isDragging: false,
+  canDrag: true,
+  setDragging: (isDragging) => set({ isDragging }),
+  setCanDrag: (canDrag) => set({ canDrag }),
+}));

--- a/app/client/src/shared/hooks/camera/index.ts
+++ b/app/client/src/shared/hooks/camera/index.ts
@@ -1,0 +1,3 @@
+export * from "./camera.context";
+export * from "./camera.provider";
+export * from "./use-camera";

--- a/app/client/src/shared/hooks/camera/use-camera.tsx
+++ b/app/client/src/shared/hooks/camera/use-camera.tsx
@@ -1,0 +1,4 @@
+import { useContext } from "react";
+import { CameraContext } from "shared/hooks/camera/camera.context";
+
+export const useCamera = () => useContext(CameraContext);

--- a/app/client/src/shared/hooks/index.ts
+++ b/app/client/src/shared/hooks/index.ts
@@ -7,6 +7,7 @@ export * from "./router";
 export * from "./tasks";
 export * from "./private-room";
 export * from "./furniture";
+export * from "./camera";
 
 export * from "./use-character";
 export * from "./use-api";

--- a/app/client/src/shared/hooks/modal/modal.provider.tsx
+++ b/app/client/src/shared/hooks/modal/modal.provider.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode, useCallback, useMemo } from "react";
-import { ModalContext } from "shared/hooks/modal/modal.context";
+import { useCamera, ModalContext } from "shared/hooks";
 import {
   ContainerComponent,
   DragContainerComponent,
@@ -10,8 +10,6 @@ import { Modal } from "shared/enums";
 import { Point2d } from "shared/types";
 import { useModalStore } from "./modal.store";
 import { MODAL_COMPONENT_MAP, MODAL_SIZE_MAP } from "shared/consts";
-import { useProxy } from "shared/hooks";
-import { Event as ProxyEvent } from "shared/enums";
 
 type ModalProps = {
   children: ReactNode;
@@ -30,7 +28,6 @@ export const ModalProvider: React.FunctionComponent<ModalProps> = ({
     setPosition,
     isOpen,
   } = useModalStore();
-  const { emit } = useProxy();
 
   const openModal = useCallback(
     (modal: Modal) => {
@@ -66,9 +63,15 @@ export const ModalProvider: React.FunctionComponent<ModalProps> = ({
     [setPosition],
   );
 
-  const disableCamera = () => {
-    emit(ProxyEvent.DISABLE_CAMERA_MOVEMENT, {});
-  };
+  const { setCanDrag } = useCamera();
+
+  const disableCameraMovement = useCallback(() => {
+    setCanDrag(false);
+  }, [setCanDrag]);
+
+  const enableCameraMovement = useCallback(() => {
+    setCanDrag(true);
+  }, [setCanDrag]);
 
   const renderModals = useMemo(() => {
     return Object.keys(modals)
@@ -83,7 +86,9 @@ export const ModalProvider: React.FunctionComponent<ModalProps> = ({
             position={position ?? { x: 0, y: 0 }}
             visible={visible}
             eventMode={EventMode.STATIC}
-            onPointerDown={disableCamera}
+            onPointerDown={disableCameraMovement}
+            onPointerUp={enableCameraMovement}
+            onPointerLeave={enableCameraMovement}
           />
         ) : null;
       })

--- a/app/client/src/shared/hooks/modal/modal.provider.tsx
+++ b/app/client/src/shared/hooks/modal/modal.provider.tsx
@@ -3,12 +3,15 @@ import { ModalContext } from "shared/hooks/modal/modal.context";
 import {
   ContainerComponent,
   DragContainerComponent,
+  EventMode,
   useWindow,
 } from "@openhotel/pixi-components";
 import { Modal } from "shared/enums";
 import { Point2d } from "shared/types";
 import { useModalStore } from "./modal.store";
 import { MODAL_COMPONENT_MAP, MODAL_SIZE_MAP } from "shared/consts";
+import { useProxy } from "shared/hooks";
+import { Event as ProxyEvent } from "shared/enums";
 
 type ModalProps = {
   children: ReactNode;
@@ -27,6 +30,7 @@ export const ModalProvider: React.FunctionComponent<ModalProps> = ({
     setPosition,
     isOpen,
   } = useModalStore();
+  const { emit } = useProxy();
 
   const openModal = useCallback(
     (modal: Modal) => {
@@ -62,6 +66,10 @@ export const ModalProvider: React.FunctionComponent<ModalProps> = ({
     [setPosition],
   );
 
+  const disableCamera = () => {
+    emit(ProxyEvent.DISABLE_CAMERA_MOVEMENT, {});
+  };
+
   const renderModals = useMemo(() => {
     return Object.keys(modals)
       .map((modal: any) => {
@@ -74,6 +82,8 @@ export const ModalProvider: React.FunctionComponent<ModalProps> = ({
             children={<Modal />}
             position={position ?? { x: 0, y: 0 }}
             visible={visible}
+            eventMode={EventMode.STATIC}
+            onPointerDown={disableCamera}
           />
         ) : null;
       })

--- a/app/server/src/shared/enums/event.enum.ts
+++ b/app/server/src/shared/enums/event.enum.ts
@@ -51,6 +51,7 @@ export enum ProxyEvent {
   SYSTEM_MESSAGE = "system-message",
 
   REDIRECT = "redirect",
+  DISABLE_CAMERA_MOVEMENT = "disable-camera-movement",
 }
 
 export enum OnetEvent {


### PR DESCRIPTION
- Allow camera movement in rooms
- Player only moving onPointerUp (and not having dragged before)
- Improved margins for room since last implementation
- Disable camera on clicking modal
- Allow camera movement on mobile
- Uses own component and provider

<s>There's a bug where it seems like 2 events can't be triggered at the same time??? Check discord. Drafter till then.</s>
There's another bug where for a brief second you are able to move even if you clicked the modal first because of (I guess) some race conditions when Disabling the camera:

![bug](https://github.com/user-attachments/assets/9d0a8bf1-3c8e-42ff-9cc5-087a67fbd039)



