### PR TITLE
feat: add autowidth to buttons - fix #829

### DIFF
--- a/app/client/src/assets/locales/en.json
+++ b/app/client/src/assets/locales/en.json
@@ -33,7 +33,7 @@
   "economy": {
     "purse_title": "Purse",
     "credits": "credits",
-    "buy": "buy"
+    "buy": "Buy"
   },
   "catalog": {
     "title": "Catalog"

--- a/app/client/src/assets/locales/es.json
+++ b/app/client/src/assets/locales/es.json
@@ -32,7 +32,7 @@
   "economy": {
     "purse_title": "Monedero",
     "credits": "creditos",
-    "buy": "comprar"
+    "buy": "Comprar"
   },
   "catalog": {
     "title": "Catalogo"

--- a/app/client/src/modules/modals/components/catalog/components/category/components/default-category/default-category.component.tsx
+++ b/app/client/src/modules/modals/components/catalog/components/category/components/default-category/default-category.component.tsx
@@ -206,9 +206,9 @@ export const DefaultCategoryComponent: React.FC<Props> = ({
             </FlexContainerComponent>
             <ButtonComponent
               size={{
-                width: 37,
                 height: 14,
               }}
+              autoWidth={true}
               text={t("economy.buy")}
               onPointerUp={onBuyFurniture}
             />

--- a/app/client/src/modules/modals/components/navigator/components/category-rooms/components/room-preview/room-preview.component.tsx
+++ b/app/client/src/modules/modals/components/navigator/components/category-rooms/components/room-preview/room-preview.component.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useState } from "react";
 import {
   ContainerComponent,
   ContainerProps,
+  FLEX_ALIGN,
   FLEX_JUSTIFY,
   FlexContainerComponent,
   NineSliceSpriteComponent,
@@ -92,27 +93,23 @@ export const RoomPreviewComponent: React.FC<Props> = ({
         />
         <FlexContainerComponent
           size={{
-            width: size.width - 37 - 3 - 5,
-          }}
-          position={{
-            y: 7,
+            width: size.width - 3,
+            height: 20,
           }}
           justify={FLEX_JUSTIFY.END}
+          align={FLEX_ALIGN.CENTER}
+          gap={6}
         >
           <TextComponent text={`${room.users}/${room.maxUsers}`} color={0} />
+          <ButtonComponent
+            size={{
+              height: 14,
+            }}
+            autoWidth={true}
+            text={t("navigator.join")}
+            onPointerDown={onJoin}
+          />
         </FlexContainerComponent>
-        <ButtonComponent
-          size={{
-            width: 37,
-            height: 14,
-          }}
-          position={{
-            x: size.width - 37 - 3,
-            y: 3,
-          }}
-          text={t("navigator.join")}
-          onPointerDown={onJoin}
-        />
       </ContainerComponent>
     </ContainerComponent>
   );

--- a/app/client/src/modules/private-room/private-room.component.tsx
+++ b/app/client/src/modules/private-room/private-room.component.tsx
@@ -208,7 +208,6 @@ export const PrivateRoomComponent: React.FC<Props> = () => {
 
   const onPointerTile = useCallback(
     (position: Point3d) => {
-      console.log(isDragging());
       if (isDragging()) return;
 
       if (isShiftDown) {

--- a/app/client/src/shared/components/button/button.component.tsx
+++ b/app/client/src/shared/components/button/button.component.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import {
   ContainerComponent,
   ContainerProps,
@@ -44,7 +44,10 @@ export const ButtonComponent: React.FC<Props> = ({
   const { getTextLength } = useText(SpriteSheetEnum.DEFAULT_FONT);
 
   // @ts-ignore
-  const width = autoWidth ? getTextLength(text) + 8 : size.width;
+  const width = useMemo(
+    () => (autoWidth ? getTextLength(text) + 16 : (size as Size).width),
+    [autoWidth, getTextLength, size],
+  );
 
   return (
     <ContainerComponent

--- a/app/client/src/shared/components/button/button.component.tsx
+++ b/app/client/src/shared/components/button/button.component.tsx
@@ -9,26 +9,42 @@ import {
   FlexContainerComponent,
   NineSliceSpriteComponent,
   Size,
+  useText,
 } from "@openhotel/pixi-components";
 import { SpriteSheetEnum } from "shared/enums";
 import { TextComponent } from "shared/components/text";
 
-type Props = {
+type BaseProps = ContainerProps & {
   text: string;
-  size: Size;
   color?: number;
-} & ContainerProps;
+};
+
+type Props =
+  | (BaseProps & {
+      autoWidth: true;
+      size?: Omit<Size, "width"> & { height: number };
+    })
+  | (BaseProps & {
+      autoWidth?: false;
+      size: Size;
+    });
 
 export const ButtonComponent: React.FC<Props> = ({
   text,
   size,
   color,
+  autoWidth,
   ...containerProps
 }) => {
   const [tint, setTint] = useState<number>(0xffffff);
 
   const onPointerEnter = useCallback(() => setTint(0xe0e0e0), [setTint]);
   const onPointerLeave = useCallback(() => setTint(0xffffff), [setTint]);
+
+  const { getTextLength } = useText(SpriteSheetEnum.DEFAULT_FONT);
+
+  // @ts-ignore
+  const width = autoWidth ? getTextLength(text) + 8 : size.width;
 
   return (
     <ContainerComponent
@@ -45,14 +61,14 @@ export const ButtonComponent: React.FC<Props> = ({
         rightWidth={3}
         topHeight={3}
         bottomHeight={3}
-        width={size.width}
+        width={width}
         height={size.height}
         eventMode={EventMode.STATIC}
         cursor={Cursor.POINTER}
         tint={tint}
       />
       <FlexContainerComponent
-        size={size}
+        size={{ width: width, height: size.height }}
         justify={FLEX_JUSTIFY.CENTER}
         align={FLEX_ALIGN.CENTER}
       >

--- a/app/client/src/shared/hooks/modal/modal.provider.tsx
+++ b/app/client/src/shared/hooks/modal/modal.provider.tsx
@@ -90,7 +90,6 @@ export const ModalProvider: React.FunctionComponent<ModalProps> = ({
 
   const disableCameraMovement = useCallback(() => {
     setCanDrag(false);
-    console.log("< false");
   }, [setCanDrag]);
 
   const enableCameraMovement = useCallback(() => {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/7a752492-eafe-467c-90bd-a5e6e4ebe6dd)

![image](https://github.com/user-attachments/assets/4127433b-823d-471f-96e4-9792cdf1c54d)

New attribute called "autoWidth" to buttons so their width can be calculated.

Modified a bit the "Join" button components because they were too hardcoded to adapt to the new autowidth.

NOTES:

Didn't do anything with autoheight since it's a more bit tricky and not that useful in our current state.