### PR TITLE
fix: teleport triggering animation - fix #912

### DIFF
--- a/app/client/src/modules/private-room/components/room-characters/room-characters.component.tsx
+++ b/app/client/src/modules/private-room/components/room-characters/room-characters.component.tsx
@@ -38,9 +38,7 @@ export const RoomCharactersComponent: React.FC = () => {
 
     const removeOnSetPositionHuman = on(
       ProxyEvent.SET_POSITION_HUMAN,
-      ({ accountId, position, bodyDirection }) => {
-        // Works as a teleport. 'setUserTargetPosition' needs to be called or the 'room-character' will trigger the walk animation
-        setUserTargetPosition(accountId, null, bodyDirection);
+      ({ accountId, position }) => {
         setUserPosition(accountId, position);
       },
     );

--- a/app/client/src/modules/private-room/components/room-characters/room-characters.component.tsx
+++ b/app/client/src/modules/private-room/components/room-characters/room-characters.component.tsx
@@ -38,7 +38,9 @@ export const RoomCharactersComponent: React.FC = () => {
 
     const removeOnSetPositionHuman = on(
       ProxyEvent.SET_POSITION_HUMAN,
-      ({ accountId, position }) => {
+      ({ accountId, position, bodyDirection }) => {
+        // Works as a teleport. 'setUserTargetPosition' needs to be called or the 'room-character' will trigger the walk animation
+        setUserTargetPosition(accountId, null, bodyDirection);
         setUserPosition(accountId, position);
       },
     );

--- a/app/client/src/shared/hooks/private-room/private-room.provider.tsx
+++ b/app/client/src/shared/hooks/private-room/private-room.provider.tsx
@@ -83,7 +83,7 @@ export const PrivateRoomProvider: React.FunctionComponent<PrivateRoomProps> = ({
   const $setUserTargetPosition = useCallback(
     (accountId: string, position: Point3d, bodyDirection?: Direction) =>
       room && setUserTargetPosition(accountId, position, bodyDirection),
-    [setUserPosition, room],
+    [setUserTargetPosition, room],
   );
   const $addFurniture = useCallback(
     (furniture: RoomFurniture) => room && addFurniture(furniture),

--- a/app/client/src/shared/hooks/private-room/private-room.store.ts
+++ b/app/client/src/shared/hooks/private-room/private-room.store.ts
@@ -92,6 +92,7 @@ export const usePrivateRoomStore = create<{
                 ...user,
                 position,
                 bodyDirection: bodyDirection ?? user.bodyDirection,
+                targetPosition: null,
                 positionUpdatedAt: Date.now(),
               }
             : user,


### PR DESCRIPTION
It prevents the animation to be triggered, since it shouldn't have a target position (because we are instantly teleporting to a position). Could have been done by passing a flag or creating a "setUserPositionTeleport", and combine both setUserPosition and setUserPositionTarget, but I think this is clear enough.

I think this would have also affected the in-game teleports, so 2 for 1.