### PR TITLE
type: fix chat ereased on player move - fix #1051

### DIFF
--- a/app/client/src/modules/private-room/components/room-messages/room-messages.component.tsx
+++ b/app/client/src/modules/private-room/components/room-messages/room-messages.component.tsx
@@ -1,29 +1,17 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
-import {
-  ContainerComponent,
-  ContainerProps,
-  Event as OhEvent,
-  useEvents,
-  useWindow,
-} from "@openhotel/pixi-components";
+import { ContainerComponent, ContainerProps, Event as OhEvent, useEvents, useWindow } from "@openhotel/pixi-components";
 import { useAccount, usePrivateRoom, useProxy, useTasks } from "shared/hooks";
 import { Event } from "shared/enums";
 import { RoomMessage, Size2d } from "shared/types";
 import { getPositionFromIsometricPosition } from "shared/utils";
 import { BubbleMessageComponent } from "shared/components";
-import {
-  BUBBLE_MESSAGE_HEIGHT,
-  CHAT_BUBBLE_MESSAGE_INTERVAL,
-  MIN_SAFE_MESSAGES,
-} from "shared/consts";
+import { BUBBLE_MESSAGE_HEIGHT, CHAT_BUBBLE_MESSAGE_INTERVAL, MIN_SAFE_MESSAGES } from "shared/consts";
 import { ulid } from "ulidx";
 import { TickerQueue } from "@oh/queue";
 
 type Props = {} & ContainerProps;
 
-export const RoomMessagesComponent: React.FC<Props> = ({
-  ...containerProps
-}) => {
+export const RoomMessagesComponent: React.FC<Props> = ({ ...containerProps }) => {
   const { on } = useEvents();
   const { getSize } = useWindow();
   const { on: onProxy } = useProxy();
@@ -58,7 +46,7 @@ export const RoomMessagesComponent: React.FC<Props> = ({
 
       setMessages(($messages) => [message, ...$messages]);
     },
-    [setMessages, getUser, currentAccount, maxMessages],
+    [setMessages, getUser, currentAccount, maxMessages]
   );
 
   useEffect(() => {
@@ -68,64 +56,51 @@ export const RoomMessagesComponent: React.FC<Props> = ({
     setMessages([]);
     setYPivot(0);
 
-    const removeOnMessage = onProxy(
-      Event.MESSAGE,
-      ({ id, accountId, message, color }) => {
-        addMessage({
-          id,
-          accountId,
-          message,
-          color,
-        });
-      },
+    const removeOnMessage = onProxy(Event.MESSAGE, ({ id, accountId, message, color }) => {
+      addMessage({
+        id,
+        accountId,
+        message,
+        color,
+      });
+    });
+
+    const removeOnWhisperMessage = onProxy(Event.WHISPER_MESSAGE, ({ id, accountId, message, color }) =>
+      addMessage({
+        id,
+        accountId,
+        message,
+        color,
+        backgroundColor: 0xc1bfbf,
+      })
     );
 
-    const removeOnWhisperMessage = onProxy(
-      Event.WHISPER_MESSAGE,
-      ({ id, accountId, message, color }) =>
-        addMessage({
-          id,
-          accountId,
-          message,
-          color,
-          backgroundColor: 0xc1bfbf,
-        }),
-    );
-
-    const removeOnSystemMessage = onProxy(
-      Event.SYSTEM_MESSAGE,
-      ({ message }) => {
-        addMessage({
-          id: ulid(),
-          accountId: null,
-          username: "System",
-          message,
-          usernameColor: 0xffffff,
-          color: 0xffffff,
-          backgroundColor: 0xdba935,
-          messageColor: 0xffffff,
-        });
-        console.log(`System: ${message}`);
-      },
-    );
+    const removeOnSystemMessage = onProxy(Event.SYSTEM_MESSAGE, ({ message }) => {
+      addMessage({
+        id: ulid(),
+        accountId: null,
+        username: "System",
+        message,
+        usernameColor: 0xffffff,
+        color: 0xffffff,
+        backgroundColor: 0xdba935,
+        messageColor: 0xffffff,
+      });
+      console.log(`System: ${message}`);
+    });
 
     return () => {
       removeOnMessage();
       removeOnWhisperMessage();
       removeOnSystemMessage();
     };
-  }, [room?.id, addMessage, getUser, onProxy, setMessages, setYPivot]);
+  }, [room?.id, onProxy]);
 
   const onResize = useCallback(
     (size: Size2d) => {
-      setMaxMessages(
-        Math.max(
-          MIN_SAFE_MESSAGES,
-          Math.round(Math.round(size.height / 4) / BUBBLE_MESSAGE_HEIGHT),
-        ),
-      );
+      setMaxMessages(Math.max(MIN_SAFE_MESSAGES, Math.round(Math.round(size.height / 4) / BUBBLE_MESSAGE_HEIGHT)));
     },
-    [setMaxMessages],
+    [setMaxMessages]
   );
 
   useEffect(() => {
@@ -150,11 +125,7 @@ export const RoomMessagesComponent: React.FC<Props> = ({
           type: TickerQueue.DURATION,
           duration: 500,
           onFunc: (delta) => {
-            setYPivot((y) =>
-              y >= BUBBLE_MESSAGE_HEIGHT
-                ? BUBBLE_MESSAGE_HEIGHT
-                : y + delta / 10,
-            );
+            setYPivot((y) => (y >= BUBBLE_MESSAGE_HEIGHT ? BUBBLE_MESSAGE_HEIGHT : y + delta / 10));
           },
           onDone: () => {
             setYPivot(0);
@@ -177,11 +148,7 @@ export const RoomMessagesComponent: React.FC<Props> = ({
         },
         onDone: () => {
           setYPivot(0);
-          setMessages(($messages) =>
-            $messages.map((message) =>
-              message ? { ...message, visible: true } : message,
-            ),
-          );
+          setMessages(($messages) => $messages.map((message) => (message ? { ...message, visible: true } : message)));
         },
       });
     }
@@ -197,16 +164,7 @@ export const RoomMessagesComponent: React.FC<Props> = ({
     () =>
       messages.map((messageData, index) => {
         if (!messageData) return null;
-        const {
-          id,
-          username,
-          message,
-          backgroundColor,
-          color,
-          usernameColor,
-          messageColor,
-          position,
-        } = messageData;
+        const { id, username, message, backgroundColor, color, usernameColor, messageColor, position } = messageData;
         return (
           <BubbleMessageComponent
             key={id}
@@ -224,7 +182,7 @@ export const RoomMessagesComponent: React.FC<Props> = ({
           />
         );
       }),
-    [messages],
+    [messages]
   );
 
   return useMemo(
@@ -239,6 +197,6 @@ export const RoomMessagesComponent: React.FC<Props> = ({
         {renderMessages}
       </ContainerComponent>
     ),
-    [renderMessages, containerProps],
+    [renderMessages, containerProps]
   );
 };


### PR DESCRIPTION
This PR fixes the chat reset so it only runs when the room actually changes (by scoping the effect to `room.id` and `onProxy`), preventing messages from being cleared when the player moves, and removes unneeded dependencies from related callbacks.